### PR TITLE
feat: allow restarts in docker adapter, new testing scripts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,33 @@
+# Git
+.git
+.gitignore
+
+# Docker
+Dockerfile
+docker-compose*.yml
+.docker
+
+# Directories
+volumes/
+templates/
+scripts/
+
+# Build artifacts
+bin/
+dist/
+
+# IDE
+.idea/
+.vscode/
+
+# OS
+.DS_Store
+
+# Test files
+*_test.go
+testdata/
+
+# Other
+*.md
+LICENSE
+.goreleaser.yaml 

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ go.work.sum
 # env file
 .env
 .idea
+
+# Testing directories
+/volumes
+docker-compose.testing-*.yml

--- a/CustomAgent.md
+++ b/CustomAgent.md
@@ -144,7 +144,7 @@ task integration-tests
 
 ```bash
 # Start a local PostgreSQL instance
-task start-demo-postgres
+task start-dev-postgres
 
 # Run the agent in debug mode
 go run cmd/agent.go

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,27 @@
-FROM golang:1.23-alpine
+FROM golang:1.23-alpine AS builder
 
 WORKDIR /app
-COPY . .
 
-RUN go build -o dbtune-agent ./cmd/agent.go
+# Copy go mod files first
+COPY go.mod go.sum ./
 
-ENTRYPOINT ["/app/dbtune-agent"]
+# Download dependencies (this layer will be cached)
+RUN go mod download
+
+# Copy source code
+COPY pkg/ pkg/
+COPY cmd/ cmd/
+
+# Build the application
+RUN CGO_ENABLED=0 GOOS=linux go build -o dbtune-agent ./cmd/agent.go
+
+# Use a minimal image for the final stage
+FROM alpine:latest
+
+WORKDIR /app
+
+# Copy the binary from builder stage
+COPY --from=builder /app/dbtune-agent .
+
+# Run the binary
+ENTRYPOINT ["./dbtune-agent"]

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,11 +1,25 @@
 version: "3"
 
-# Work in progress, right now testing and tasks are ad-hoc
 tasks:
-  start-demo-postgres:
+  start-dev-postgres:
+    desc: Start development postgresql instance
     cmds:
-      - docker rm -f demo-postgres
-      - docker run --name demo-postgres --memory="100m" -e POSTGRES_PASSWORD=password -e POSTGRES_USER=dbtune -p 1994:5432 -d postgres -c shared_preload_libraries=pg_stat_statements -c pg_stat_statements.track=all
-      # TODO: When starting the demo postgresql we need to create the extension pg_stat_statements, maybe we need a custom entry and use a docker compose file, will revisit this
-      # - docker exec -it demo-postgres psql -U dbtune -d dbtune -c "CREATE EXTENSION pg_stat_statements;"
-    silent: true
+      - docker rm -f dev-postgres
+      - mkdir -p ./volumes/dev-postgres
+      - docker run --name dev-postgres
+        --memory="500m"
+        -e POSTGRES_PASSWORD=password
+        -e POSTGRES_USER=dbtune
+        -p 1994:5432
+        -v ./volumes/dev-postgres:/var/lib/postgresql/data
+        -v ./templates/init.sql:/docker-entrypoint-initdb.d/init.sql
+        -d postgres
+        -c shared_preload_libraries=pg_stat_statements
+        -c pg_stat_statements.track=all
+    silent: false
+
+  start-testing-db:
+    desc: Start a new testing database with agent
+    cmds:
+      - ./scripts/local-testing.sh
+    silent: false

--- a/dbtune.yaml
+++ b/dbtune.yaml
@@ -6,7 +6,7 @@ postgresql:
 
 # Use with docker flag to monitor a PostgreSQL container
 docker:
-  container_name: demo-postgres
+  container_name: dev-postgres
 
 dbtune:
   server_url: https://app.dbtune.com

--- a/scripts/local-testing.sh
+++ b/scripts/local-testing.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# This script is used to start a local testing database for development purposes.
+# It requires SD and JQ to be installed.
+# It used the DBtune platform and requires two env variables to be set:
+# - DBT_DBTUNE_API_KEY
+# - DBT_DBTUNE_SERVER_URL
+#
+# The script will:
+# 1. Create a new database in the DBtune platform you are targeting and grab the ID
+# 2. Start a new local compose file that will be used to start the database with an agent connected to it
+
+set -e
+
+
+if [ -z "${DBT_DBTUNE_API_KEY}" ] || [ -z "${DBT_DBTUNE_SERVER_URL}" ]; then
+  echo "Error: DBT_DBTUNE_API_KEY and DBT_DBTUNE_SERVER_URL must be set"
+  exit 1
+fi
+
+# Check if jq is installed
+if ! command -v jq &> /dev/null; then
+  echo "Error: jq is required but not installed. Please install jq first."
+  exit 1
+fi
+
+# Check if sd is installed
+if ! command -v sd &> /dev/null; then
+  echo "Error: sd is required but not installed. Please install sd first."
+  exit 1
+fi
+
+UUID=$(uuidgen | tr '[:upper:]' '[:lower:]')
+DB_NAME="testing-db-${UUID}"
+echo "Generated DB name: ${DB_NAME}"
+
+# Create database through API
+echo "Creating database through API..."
+RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "${DBT_DBTUNE_SERVER_URL}/api/v1/databases" \
+  -H "DBTUNE-API-KEY: ${DBT_DBTUNE_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "'"${DB_NAME}"'",
+    "restart_policy": true,
+    "db_engine": "postgresql",
+    "cloud_provider": "AWS",
+    "hosting": "on_prem",
+    "tuning_target": "average_query_runtime",
+    "iteration_duration": 0.1
+  }')
+
+HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+BODY=$(echo "$RESPONSE" | sed '$d')
+
+if [ "$HTTP_CODE" != "200" ] && [ "$HTTP_CODE" != "201" ]; then
+  echo "Error creating database. HTTP Code: $HTTP_CODE"
+  echo "Response: $BODY"
+  exit 1
+fi
+
+# Extract the database UUID from the response using jq
+DATABASE_UUID=$(echo "$BODY" | jq -r '.uuid')
+if [ -z "$DATABASE_UUID" ] || [ "$DATABASE_UUID" = "null" ]; then
+  echo "Error: Could not extract database UUID from response"
+  echo "Response: $BODY"
+  exit 1
+fi
+echo "Database UUID: ${DATABASE_UUID}"
+
+# Create volumes directory if it doesn't exist
+echo "Creating volumes directory..."
+mkdir -p volumes
+
+# Convert localhost to host.docker.internal for the agent
+# for local development
+AGENT_SERVER_URL=$(echo "${DBT_DBTUNE_SERVER_URL}" | sed 's/localhost/host.docker.internal/')
+
+# Use sd to replace placeholders in the template
+echo "Creating docker-compose file..."
+cp templates/docker-compose.yml "docker-compose.${DB_NAME}.yml"
+sd "DB_NAME" "${DB_NAME}" "docker-compose.${DB_NAME}.yml"
+sd "DB_DATA_DIR" "${DB_NAME}" "docker-compose.${DB_NAME}.yml"
+sd "DB_NETWORK_NAME" "${DB_NAME}_net" "docker-compose.${DB_NAME}.yml"
+sd "SD_API_KEY" "${DBT_DBTUNE_API_KEY}" "docker-compose.${DB_NAME}.yml"
+sd "SD_SERVER_URL" "${AGENT_SERVER_URL}" "docker-compose.${DB_NAME}.yml"
+sd "DATABASE_UUID" "${DATABASE_UUID}" "docker-compose.${DB_NAME}.yml"
+
+# Start the services
+echo "Starting services..."
+docker compose -f "docker-compose.${DB_NAME}.yml" up -d
+
+echo "Setup completed successfully 🫡"

--- a/templates/docker-compose.yml
+++ b/templates/docker-compose.yml
@@ -1,0 +1,50 @@
+name: DB_NAME
+
+services:
+  postgres:
+    image: postgres:latest
+    container_name: DB_NAME
+    hostname: postgres
+    mem_limit: 500m
+    cpus: 1
+    environment:
+      POSTGRES_PASSWORD: password
+      POSTGRES_USER: dbtune
+      POSTGRES_DB: dbtune
+    volumes:
+      - ./volumes/DB_DATA_DIR:/var/lib/postgresql/data
+      - ./templates/init.sql:/docker-entrypoint-initdb.d/init.sql
+    command: 
+      - "postgres"
+      - "-c"
+      - "shared_preload_libraries=pg_stat_statements"
+      - "-c"
+      - "pg_stat_statements.track=all"
+    networks:
+      DB_NETWORK:
+        aliases:
+          - postgres
+
+  agent:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: --docker
+    environment:
+      - DBT_POSTGRESQL_CONNECTION_URL=postgresql://dbtune:password@postgres:5432/dbtune
+      - DBT_DBTUNE_API_KEY=SD_API_KEY
+      - DBT_DBTUNE_SERVER_URL=SD_SERVER_URL
+      - DBT_DBTUNE_DATABASE_ID=DATABASE_UUID
+      - DBT_ADAPTER=docker
+      - DBT_DOCKER_CONTAINER_NAME=DB_NAME
+    networks:
+      - DB_NETWORK
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    volumes:
+      - ./dbtune.yaml:/app/dbtune.yaml
+      - /var/run/docker.sock:/var/run/docker.sock
+
+networks:
+  DB_NETWORK:
+    name: DB_NETWORK_NAME

--- a/templates/init.sql
+++ b/templates/init.sql
@@ -1,0 +1,1 @@
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements; 


### PR DESCRIPTION
This PR includes:
1. New functionality to the default docker adapter to allow restarts (we need to have mounted instances else its useless)
2. Scripts to:
  a. Start new PG instance for debugging
  b. Start new compose with PG instance and an agent for debugging