### PR TITLE
fix: docker negotiation api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/dbtuneai/agent
 go 1.23.1
 
 require (
-	github.com/docker/docker v27.4.1+incompatible
+	github.com/docker/docker v27.5.1+incompatible
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/jackc/pgx/v5 v5.7.1
 	github.com/jaypipes/ghw v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
-github.com/docker/docker v27.4.1+incompatible h1:ZJvcY7gfwHn1JF48PfbyXg7Jyt9ZCWDW+GGXOIxEwp4=
-github.com/docker/docker v27.4.1+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v27.5.1+incompatible h1:4PYU5dnBYqRQi0294d1FBECqT9ECWeQAIfE8q4YnPY8=
+github.com/docker/docker v27.5.1+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj1Br63c=
 github.com/docker/go-connections v0.5.0/go.mod h1:ov60Kzw0kKElRwhNs9UlUHAE/F9Fe6GLaXnqyDdmEXc=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=

--- a/pkg/adapters/docker_container.go
+++ b/pkg/adapters/docker_container.go
@@ -43,7 +43,7 @@ func CreateDockerContainerAdapter() (*DockerContainerAdapter, error) {
 	}
 
 	// Create Docker client
-	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	cli, err := client.NewClientWithOpts(client.WithAPIVersionNegotiation())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Docker client: %w", err)
 	}

--- a/pkg/collectors/docker_collectors.go
+++ b/pkg/collectors/docker_collectors.go
@@ -9,18 +9,12 @@ import (
 	"github.com/dbtuneai/agent/pkg/internal/utils"
 
 	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/client"
 )
 
 // DockerHardwareInfo collects hardware metrics from a Docker container using the Docker API
 func DockerHardwareInfo(dockerAdapter adapters.DockerAdapter) func(ctx context.Context, state *agent.MetricsState) error {
 	return func(ctx context.Context, state *agent.MetricsState) error {
-		// Create a new Docker client
-		cli, err := client.NewClientWithOpts(client.FromEnv)
-		if err != nil {
-			return err
-		}
-		defer cli.Close()
+		cli := dockerAdapter.GetDockerClient()
 
 		// Get container stats
 		containerName := dockerAdapter.GetContainerName()
@@ -45,12 +39,6 @@ func DockerHardwareInfo(dockerAdapter adapters.DockerAdapter) func(ctx context.C
 			statsJSON.PreCPUStats.SystemUsage,
 			&statsJSON,
 		)
-
-		// // Calculate memory percentage
-		// memoryPercent := float64(statsJSON.MemoryStats.Usage) / float64(statsJSON.MemoryStats.Limit) * 100
-
-		// memPercentMetric, _ := utils.NewMetric("node_memory_usage", memoryPercent, utils.Float)
-		// state.AddMetric(memPercentMetric)
 
 		// Add metrics
 		cpuMetric, _ := utils.NewMetric("node_cpu_usage", cpuPercent, utils.Float)


### PR DESCRIPTION
This PR includes:
1. Remove the re-initialisation of Docker client when we fetch hardware metrics
2. Use the `WithAPIVersionNegotiation` to avoid errors of incompatibility
3. Update Docker SDK version to the latest