### PR TITLE
Incorrect calculation of used memory for on prem postgres.

### DIFF
--- a/pkg/adapters/postgres.go
+++ b/pkg/adapters/postgres.go
@@ -388,7 +388,7 @@ func (adapter *DefaultPostgreSQLAdapter) Guardrails() *agent.GuardrailType {
 	}
 
 	// Calculate memory usage percentage
-	memoryUsagePercent := float64(memoryInfo.Used) / float64(memoryInfo.Total) * 100
+	memoryUsagePercent := float64(memoryInfo.Total-memoryInfo.Available) / float64(memoryInfo.Total) * 100
 
 	adapter.Logger().Debugf("Memory usage: %f%%", memoryUsagePercent)
 

--- a/pkg/collectors/collectors.go
+++ b/pkg/collectors/collectors.go
@@ -372,7 +372,7 @@ func HardwareInfoOnPremise(pgAdapter adeptersinterfaces.PostgreSQLAdapter) func(
 
 		// Memory usage
 		memoryInfo, _ := mem.VirtualMemory()
-		usedMemory, _ := utils.NewMetric("node_memory_used", memoryInfo.Used, utils.Int)
+		usedMemory, _ := utils.NewMetric("node_memory_used", memoryInfo.Total-memoryInfo.Available, utils.Int)
 		state.AddMetric(usedMemory)
 
 		return nil


### PR DESCRIPTION
Closes DBT-535

This PR includes:
1. Incorrect calculation of used memory in on prem postgres adapter.

