### PR TITLE
feat: add more auth methods for aws

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ docker:
 # Aurora-specific settings
 rds-aurora:
   AWS_REGION: "<your-aws-region>"
+  # AWS credentials are optional
+  # If not provided, the agent will use the default AWS credential chain, which includes WebIdentity tokens
   AWS_ACCESS_KEY_ID: "<your-aws-access-key-id>"
   AWS_SECRET_ACCESS_KEY: "<your-aws-secret-access-key>"
   RDS_DATABASE_IDENTIFIER: "<your-rds-database-identifier>" # The Writer instance of the Aurora cluster

--- a/pkg/adeptersinterfaces/common.go
+++ b/pkg/adeptersinterfaces/common.go
@@ -52,8 +52,8 @@ type AuroraRDSState struct {
 }
 
 type AuroraRDSConfig struct {
-	AWSAccessKey          string `mapstructure:"AWS_ACCESS_KEY_ID" validate:"required"`
-	AWSSecretAccessKey    string `mapstructure:"AWS_SECRET_ACCESS_KEY" validate:"required"`
+	AWSAccessKey          string `mapstructure:"AWS_ACCESS_KEY_ID"`
+	AWSSecretAccessKey    string `mapstructure:"AWS_SECRET_ACCESS_KEY"`
 	AWSRegion             string `mapstructure:"AWS_REGION" validate:"required"`
 	RDSDatabaseIdentifier string `mapstructure:"RDS_DATABASE_IDENTIFIER" validate:"required"`
 	RDSParameterGroupName string `mapstructure:"RDS_PARAMETER_GROUP_NAME" validate:"required"`


### PR DESCRIPTION
Closes DBT-558

Based on feedback from clients, their K8s cluster is using `AWS_WEB_IDENTITY_TOKEN_FILE` to authenticate services