### PR TITLE
feat: add pg_stat_statements diff snapshots support

### DIFF
--- a/pkg/adapters/aurora_rds.go
+++ b/pkg/adapters/aurora_rds.go
@@ -292,7 +292,7 @@ func AuroraCollectors(adapter *AuroraRDSAdapter) []agent.MetricCollector {
 		{
 			Key:        "database_average_query_runtime",
 			MetricType: "float",
-			Collector:  collectors.QueryRuntime(adapter),
+			Collector:  collectors.PGStatStatements(adapter),
 		},
 		{
 			Key:        "database_transactions_per_second",

--- a/pkg/adapters/docker_container.go
+++ b/pkg/adapters/docker_container.go
@@ -75,7 +75,7 @@ func DockerCollectors(adapter *DockerContainerAdapter) []agent.MetricCollector {
 		{
 			Key:        "database_average_query_runtime",
 			MetricType: "float",
-			Collector:  collectors.QueryRuntime(adapter),
+			Collector:  collectors.PGStatStatements(adapter),
 		},
 		{
 			Key:        "database_transactions_per_second",

--- a/pkg/adapters/postgres.go
+++ b/pkg/adapters/postgres.go
@@ -88,7 +88,7 @@ func DefaultCollectors(pgAdapter *DefaultPostgreSQLAdapter) []agent.MetricCollec
 		{
 			Key:        "database_average_query_runtime",
 			MetricType: "float",
-			Collector:  collectors.QueryRuntime(pgAdapter),
+			Collector:  collectors.PGStatStatements(pgAdapter),
 		},
 		{
 			Key:        "database_transactions_per_second",

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -182,7 +182,8 @@ type Caches struct {
 	// {
 	// 	example_query_id: {
 	// 		"query_id": example_query_id,
-	// 		"time": 1000
+	// 		"total_exec_time": 1000,
+	// 		"calls": 10,
 	// 	},
 	// }
 	QueryRuntimeList map[string]utils.CachedPGStatStatement

--- a/pkg/internal/utils/query_runtime.go
+++ b/pkg/internal/utils/query_runtime.go
@@ -1,7 +1,13 @@
 package utils
 
+import (
+	"sort"
+)
+
+var diffLimit = 100
+
 type CachedPGStatStatement struct {
-	QueryId       string  `json:"query_id"`
+	QueryID       string  `json:"query_id"`
 	Calls         int     `json:"calls"`
 	TotalExecTime float64 `json:"total_exec_time"`
 }
@@ -18,7 +24,7 @@ func CalculateQueryRuntime(prev, curr map[string]CachedPGStatStatement) float64 
 		// Get the previous stats, defaulting to zero if not found
 		prevStat, exists := prev[queryId]
 		if !exists {
-			prevStat = CachedPGStatStatement{QueryId: queryId, Calls: 0, TotalExecTime: 0.0}
+			prevStat = CachedPGStatStatement{QueryID: queryId, Calls: 0, TotalExecTime: 0.0}
 		}
 
 		// Calculate the difference in calls and execution time
@@ -38,4 +44,53 @@ func CalculateQueryRuntime(prev, curr map[string]CachedPGStatStatement) float64 
 		return 0.0
 	}
 	return totalExecTime / float64(totalCalls)
+}
+
+// CalculateQueryRuntimeDelta calculates the delta
+// between two consecutive snapshots of the pg_stat_statements and returns:
+// [{ query_id: "query_id", calls: 10, total_exec_time: 1000 }, ...]
+// The diff will be limited to only 100 different queries changed by default.
+// Also, it will return the total number of diffs found to give us an idea if a lot of information is not captured
+// The cap will be based upon their average execution time (descending)
+func CalculateQueryRuntimeDelta(prev, curr map[string]CachedPGStatStatement) ([]CachedPGStatStatement, int) {
+	diffs := []CachedPGStatStatement{}
+	totalDiffs := 0
+
+	// Calculate diffs for all queries in current snapshot
+	for queryId, currStat := range curr {
+		// Get the previous stats, defaulting to zero if not found
+		prevStat, exists := prev[queryId]
+		if !exists {
+			prevStat = CachedPGStatStatement{QueryID: queryId, Calls: 0, TotalExecTime: 0.0}
+		}
+
+		// Calculate the difference in calls and execution time
+		callsDiff := currStat.Calls - prevStat.Calls
+		execTimeDiff := currStat.TotalExecTime - prevStat.TotalExecTime
+
+		// Only consider queries that have had positive changes
+		if callsDiff > 0 && execTimeDiff > 0 {
+			totalDiffs++
+
+			diffs = append(diffs, CachedPGStatStatement{
+				QueryID:       queryId,
+				Calls:         callsDiff,
+				TotalExecTime: execTimeDiff,
+			})
+		}
+	}
+
+	// Sort diffs by average execution time (highest first)
+	sort.Slice(diffs, func(i, j int) bool {
+		avgI := diffs[i].TotalExecTime / float64(diffs[i].Calls)
+		avgJ := diffs[j].TotalExecTime / float64(diffs[j].Calls)
+		return avgI > avgJ
+	})
+
+	// Limit entries based on the specified limit
+	if len(diffs) > diffLimit {
+		diffs = diffs[:diffLimit]
+	}
+
+	return diffs, totalDiffs
 }

--- a/pkg/internal/utils/query_runtime_test.go
+++ b/pkg/internal/utils/query_runtime_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"slices"
 	"testing"
 )
 
@@ -15,33 +16,33 @@ func TestCalculateQueryRuntime(t *testing.T) {
 		{
 			name: "Basic increase in calls and exec time",
 			prev: map[string]CachedPGStatStatement{
-				"query1": {QueryId: "query1", Calls: 10, TotalExecTime: 5.0},
-				"query2": {QueryId: "query2", Calls: 10, TotalExecTime: 5.0},
+				"query1": {QueryID: "query1", Calls: 10, TotalExecTime: 5.0},
+				"query2": {QueryID: "query2", Calls: 10, TotalExecTime: 5.0},
 			},
 			curr: map[string]CachedPGStatStatement{
-				"query1": {QueryId: "query1", Calls: 20, TotalExecTime: 10.0},
-				"query2": {QueryId: "query2", Calls: 20, TotalExecTime: 10.0},
+				"query1": {QueryID: "query1", Calls: 20, TotalExecTime: 10.0},
+				"query2": {QueryID: "query2", Calls: 20, TotalExecTime: 10.0},
 			},
 			expected: 0.5, // (5 + 5) / (10 + 10) = 10 / 20 = 0.5 ms
 		},
 		{
 			name: "No increase in calls or exec time",
 			prev: map[string]CachedPGStatStatement{
-				"query1": {QueryId: "query1", Calls: 10, TotalExecTime: 100.0},
+				"query1": {QueryID: "query1", Calls: 10, TotalExecTime: 100.0},
 			},
 			curr: map[string]CachedPGStatStatement{
-				"query1": {QueryId: "query1", Calls: 10, TotalExecTime: 100.0},
+				"query1": {QueryID: "query1", Calls: 10, TotalExecTime: 100.0},
 			},
 			expected: 0.0, // No calls or exec time increase
 		},
 		{
 			name: "New query in current snapshot",
 			prev: map[string]CachedPGStatStatement{
-				"query1": {QueryId: "query1", Calls: 10, TotalExecTime: 100.0},
+				"query1": {QueryID: "query1", Calls: 10, TotalExecTime: 100.0},
 			},
 			curr: map[string]CachedPGStatStatement{
-				"query1": {QueryId: "query1", Calls: 10, TotalExecTime: 100.0},
-				"query2": {QueryId: "query2", Calls: 5, TotalExecTime: 50.0},
+				"query1": {QueryID: "query1", Calls: 10, TotalExecTime: 100.0},
+				"query2": {QueryID: "query2", Calls: 5, TotalExecTime: 50.0},
 			},
 			// ((100 - 100) + (50 - 0)) / ((10 - 10) + (5 - 0)) = 50 / 5 = 10 ms
 			expected: 10.0,
@@ -49,11 +50,11 @@ func TestCalculateQueryRuntime(t *testing.T) {
 		{
 			name: "Query removed in current snapshot",
 			prev: map[string]CachedPGStatStatement{
-				"query1": {QueryId: "query1", Calls: 10, TotalExecTime: 100.0},
-				"query2": {QueryId: "query2", Calls: 5, TotalExecTime: 50.0},
+				"query1": {QueryID: "query1", Calls: 10, TotalExecTime: 100.0},
+				"query2": {QueryID: "query2", Calls: 5, TotalExecTime: 50.0},
 			},
 			curr: map[string]CachedPGStatStatement{
-				"query1": {QueryId: "query1", Calls: 15, TotalExecTime: 150.0},
+				"query1": {QueryID: "query1", Calls: 15, TotalExecTime: 150.0},
 			},
 			expected: 10.0, // Only query1 is considered
 		},
@@ -64,6 +65,93 @@ func TestCalculateQueryRuntime(t *testing.T) {
 			result := CalculateQueryRuntime(tt.prev, tt.curr)
 			if result != tt.expected {
 				t.Errorf("expected %.2f, got %.2f", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestCalculateQueryRuntimeDelta(t *testing.T) {
+	tests := []struct {
+		name        string
+		prev        map[string]CachedPGStatStatement
+		curr        map[string]CachedPGStatStatement
+		expected    []CachedPGStatStatement
+		expectedNum int
+	}{
+		{
+			name: "Basic increase in calls and exec time",
+			prev: map[string]CachedPGStatStatement{
+				"query1": {QueryID: "query1", Calls: 10, TotalExecTime: 5.0},
+			},
+			curr: map[string]CachedPGStatStatement{
+				"query1": {QueryID: "query1", Calls: 20, TotalExecTime: 10.0},
+			},
+			expected: []CachedPGStatStatement{
+				{QueryID: "query1", Calls: 10, TotalExecTime: 5.0},
+			},
+			expectedNum: 1,
+		},
+		{
+			name: "Decrease in calls and exec time",
+			prev: map[string]CachedPGStatStatement{
+				"query1": {QueryID: "query1", Calls: 10, TotalExecTime: 5.0},
+			},
+			curr: map[string]CachedPGStatStatement{
+				"query1": {QueryID: "query1", Calls: 5, TotalExecTime: 4.0},
+			},
+			// Should not include any diff
+			expected:    []CachedPGStatStatement{},
+			expectedNum: 0,
+		},
+		{
+			name: "Entry existing only in current but not in previous",
+			prev: map[string]CachedPGStatStatement{},
+			curr: map[string]CachedPGStatStatement{
+				"query1": {QueryID: "query1", Calls: 10, TotalExecTime: 5.0},
+			},
+			expected: []CachedPGStatStatement{
+				{QueryID: "query1", Calls: 10, TotalExecTime: 5.0},
+			},
+			expectedNum: 1,
+		},
+		{
+			name: "Multiple entries with custom limit of 3",
+			prev: map[string]CachedPGStatStatement{},
+			curr: map[string]CachedPGStatStatement{
+				"query1": {QueryID: "query1", Calls: 10, TotalExecTime: 50.0},
+				"query2": {QueryID: "query2", Calls: 20, TotalExecTime: 200.0},
+				"query3": {QueryID: "query3", Calls: 5, TotalExecTime: 100.0},
+				"query4": {QueryID: "query4", Calls: 15, TotalExecTime: 45.0},
+				"query5": {QueryID: "query5", Calls: 25, TotalExecTime: 50.0},
+			},
+			expected: []CachedPGStatStatement{
+				{QueryID: "query3", Calls: 5, TotalExecTime: 100.0},
+				{QueryID: "query2", Calls: 20, TotalExecTime: 200.0},
+				{QueryID: "query1", Calls: 10, TotalExecTime: 50.0},
+			},
+			expectedNum: 5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			diffLimit = 3
+			diff, totalDiffs := CalculateQueryRuntimeDelta(tt.prev, tt.curr)
+
+			// Check total diffs
+			if totalDiffs != tt.expectedNum {
+				t.Errorf("expected %d total diffs, got %d", tt.expectedNum, totalDiffs)
+			}
+
+			// Check slice equality using slices.Equal with a custom equal function
+			equal := slices.EqualFunc(diff, tt.expected, func(a, b CachedPGStatStatement) bool {
+				return a.QueryID == b.QueryID &&
+					a.Calls == b.Calls &&
+					a.TotalExecTime == b.TotalExecTime
+			})
+
+			if !equal {
+				t.Errorf("slices are not equal\nexpected: %+v\ngot: %+v", tt.expected, diff)
 			}
 		})
 	}


### PR DESCRIPTION
Closes DBT-569

This PR includes work to:
1. Fix teh query id matching, as we can have overlaps from the same queries being executed from diff userids or targeting diff databases
2. Add support for the latest supported metric, `pgss_delta`