### PR TITLE
fix: non_critical to non-critical

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -153,7 +153,7 @@ const (
 	// NonCritical is a guardrail that is not critical
 	// to the operation of the database, but a new configuration
 	// is recommended to be applied.
-	NonCritical GuardrailType = "non_critical"
+	NonCritical GuardrailType = "non-critical"
 )
 
 type GuardrailSignal struct {


### PR DESCRIPTION
Changes criticality payload to align with what the DBtune's API expects