### PR TITLE
feat: auto-detect adapater from env/config

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -87,6 +87,9 @@ func main() {
 			adapter, err = docker.CreateDockerContainerAdapter()
 
 		} else if rds.DetectConfigFromEnv() {
+			// NOTE: This is because they both share the same environment variables and there's
+			// no easy distinction. Theoretically we could just let this run, as they have no functional
+			// differences, but better not to introduce this default behaviour incase it was to change.
 			log.Println("RDS or Aurora configuration detected")
 			log.Fatal(
 				"Ambiguous configuration detected. This can happen if using environment variables, as they" +

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -134,7 +134,6 @@ func detectProvider() (string, error) {
 	if err == nil {
 		return "aiven", nil
 	}
-	log.Printf("aiven adapter error: %v", err)
 
 	// NOTE: Important this goes last, as it normally always exists as we usually
 	// have the `postgres: in the config file`

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -98,7 +98,7 @@ func main() {
 
 		} else if aiven.DetectConfigFromConfigFile() {
 			log.Println("Aiven PostgreSQL configuration detected in config file")
-			adapter, err = pgprem.CreateDefaultPostgreSQLAdapter()
+			adapter, err = aiven.CreateAivenPostgreSQLAdapter()
 
 		} else if docker.DetectConfigFromConfigFile() {
 			log.Println("Docker container configuration detected in config file")

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -83,7 +83,7 @@ func main() {
 			adapter, err = aiven.CreateAivenPostgreSQLAdapter()
 
 		} else if docker.DetectConfigFromEnv() {
-			log.Println("Docker container adapter detected")
+			log.Println("Docker container adapter detected from environment variables")
 			adapter, err = docker.CreateDockerContainerAdapter()
 
 		} else if rds.DetectConfigFromEnv() {

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -19,7 +19,7 @@ func main() {
 	// Define flags
 	useDocker := flag.Bool("docker", false, "Use Docker adapter")
 	useAurora := flag.Bool("aurora", false, "Use Aurora adapter")
-	useRDS := flag.Bool("rds", false, "Use RDS adapater")
+	useRDS := flag.Bool("rds", false, "Use RDS adapter")
 	useAiven := flag.Bool("aiven", false, "Use Aiven PostgreSQL adapter")
 	useLocal := flag.Bool("local", false, "Use local PostgreSQL adapter")
 	flag.Parse()
@@ -117,7 +117,7 @@ func main() {
 			// NOTE: This was the previous behavior, which is consistent with our configuration.
 			// All config files have the `postgres:` subheader, which is all the local Postgres
 			// adapter requires. I would rather error out but alas.
-			log.Println("Defaulting to local PostgreSQL adapter as no other adapater was detected.")
+			log.Println("Defaulting to local PostgreSQL adapter as no other adapter was detected.")
 			adapter, err = pgprem.CreateDefaultPostgreSQLAdapter()
 		}
 		if err != nil {

--- a/pkg/aiven/config.go
+++ b/pkg/aiven/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/dbtuneai/agent/pkg/internal/utils"
 	"github.com/spf13/viper"
 )
 
@@ -57,6 +58,11 @@ func ConfigFromViper(key *string) (Config, error) {
 	err := dbtuneConfig.Unmarshal(&config)
 	if err != nil {
 		return Config{}, fmt.Errorf("unable to decode into struct: %v", err)
+	}
+
+	err = utils.ValidateStruct(&config)
+	if err != nil {
+		return Config{}, err
 	}
 
 	// Since we are specifying in units of seconds, but a raw int such as 30

--- a/pkg/aiven/config.go
+++ b/pkg/aiven/config.go
@@ -2,6 +2,7 @@ package aiven
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/dbtuneai/agent/pkg/internal/utils"
@@ -69,4 +70,24 @@ func ConfigFromViper(key *string) (Config, error) {
 	// is interpreted as nanoseconds, we need to convert it
 	config.MetricResolution = time.Duration(config.MetricResolution) * time.Second
 	return config, nil
+}
+
+func DetectConfigFromConfigFile() bool {
+	return viper.Sub(DEFAULT_CONFIG_KEY) != nil
+}
+
+func DetectConfigFromEnv() bool {
+	envKeysToDetect := []string{
+		"DBT_AIVEN_API_TOKEN",
+		"DBT_AIVEN_PROJECT_NAME",
+		"DBT_AIVEN_SERVICE_NAME",
+	}
+
+	for _, envKey := range envKeysToDetect {
+		if os.Getenv(envKey) != "" {
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/docker/config.go
+++ b/pkg/docker/config.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/dbtuneai/agent/pkg/internal/utils"
 	"github.com/spf13/viper"
@@ -41,4 +42,21 @@ func ConfigFromViper(key *string) (Config, error) {
 		return Config{}, err
 	}
 	return dockerConfig, nil
+}
+
+func DetectConfigFromConfigFile() bool {
+	return viper.Sub(DEFAULT_CONFIG_KEY) != nil
+}
+
+func DetectConfigFromEnv() bool {
+	envKeysToDetect := []string{
+		"DBT_DOCKER_CONTAINER_NAME",
+	}
+
+	for _, envKey := range envKeysToDetect {
+		if os.Getenv(envKey) != "" {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/pg/config.go
+++ b/pkg/pg/config.go
@@ -2,6 +2,7 @@ package pg
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/dbtuneai/agent/pkg/internal/utils"
 	"github.com/spf13/viper"
@@ -43,4 +44,24 @@ func ConfigFromViper(key *string) (Config, error) {
 		return Config{}, err
 	}
 	return pgConfig, nil
+}
+
+func DetectConfigFromConfigFile() bool {
+	config := viper.Sub(DEFAULT_CONFIG_KEY)
+	return config != nil
+}
+
+func DetectConfigFromEnv() bool {
+	envKeysToDetect := []string{
+		"DBT_POSTGRESQL_CONNECTION_URL",
+		// NOTE: We don't require the service name to be set,
+		"DBT_POSTGRESQL_SERVICE_NAME",
+	}
+	for _, envKey := range envKeysToDetect {
+		if os.Getenv(envKey) != "" {
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/rds/config.go
+++ b/pkg/rds/config.go
@@ -75,11 +75,6 @@ const (
 	Aurora DetectedConfig = "aurora"
 	// RDS was detected from the configuration.
 	RDS DetectedConfig = "rds"
-	// If we detect the environment variables are set, these are re-used for both
-	// RDS and Aurora, hence it's ambiguous and we require the user to specify.
-	// This does not happen for the config file as the sub-heading in the config file is
-	// different.
-	Ambiguous DetectedConfig = "ambiguous"
 	// Neither was detected, it's something else.
 	None DetectedConfig = "none"
 )


### PR DESCRIPTION
The agent now automatically tries to infer which adapter to use without the `--flag`.
It does this by first detecting if any of the correct env vars are present. It then will check the dbtune-yaml config. It defaults to `--local` which was the default before this to keep behaviour.

In this screen shot, you can see the env vars take precedence, and without them, it uses the config file which has the docker key.

<img width="1512" alt="Screenshot 2025-06-09 at 08 48 32" src="https://github.com/user-attachments/assets/dbf3ca0f-b088-41c0-bae4-3e5d4147586f" />


---

There's one annoying gotcha with this, in that the `local` mode, i.e. a postgres service which is running locally (not docker), is a valid sub-cofniguration of all others. That is because it only requires the `postgresql:` sub-header in the yaml file, which is required by all other adapters.

There's also another quirk in that `RDS` and `Aurora` both require the exact same env variable keys, and changing them now would be backwards breaking. Rather than do so, if we detect these env vars, we raise that it's ambiguous.