### PR TITLE
fix: use container CPU limits for node_cpu_count metric

### DIFF
--- a/pkg/docker/collectors.go
+++ b/pkg/docker/collectors.go
@@ -3,6 +3,7 @@ package docker
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/dbtuneai/agent/pkg/agent"
 	"github.com/dbtuneai/agent/pkg/metrics"
@@ -22,6 +23,12 @@ func DockerHardwareInfo(client *client.Client, containerName string) func(ctx co
 		}
 		defer stats.Body.Close()
 
+		// Get container info for CPU limits
+		containerInfo, err := client.ContainerInspect(ctx, containerName)
+		if err != nil {
+			return err
+		}
+
 		// Parse stats and create metrics
 		var statsJSON container.StatsResponse
 
@@ -39,14 +46,47 @@ func DockerHardwareInfo(client *client.Client, containerName string) func(ctx co
 		)
 
 		// Add metrics
-		cpuMetric, _ := metrics.NodeCPUUsage.AsFlatValue(cpuPercent)
+		cpuMetric, err := metrics.NodeCPUUsage.AsFlatValue(cpuPercent)
+		if err != nil {
+			return err
+		}
 		state.AddMetric(cpuMetric)
 
+		// Add CPU count metric from container limits
+		var cpuCount float64
+		if containerInfo.HostConfig.NanoCPUs > 0 {
+			// Convert from nano CPUs to actual CPU count
+			cpuCount = float64(containerInfo.HostConfig.NanoCPUs) / 1e9
+		} else if containerInfo.HostConfig.CPUQuota > 0 && containerInfo.HostConfig.CPUPeriod > 0 {
+			// Convert from quota/period to CPU count
+			cpuCount = float64(containerInfo.HostConfig.CPUQuota) / float64(containerInfo.HostConfig.CPUPeriod)
+		} else {
+			// If no limits set, use the number of CPUs available to the container
+			cpuCount = float64(len(statsJSON.CPUStats.CPUUsage.PercpuUsage))
+		}
+
+		cpuCountMetric, err := metrics.NodeCPUCount.AsFlatValue(int64(cpuCount))
+		if err != nil {
+			return err
+		}
+		state.AddMetric(cpuCountMetric)
+
+		// Validate memory stats before calculating
+		if statsJSON.MemoryStats.Usage == 0 {
+			return fmt.Errorf("invalid memory stats: usage is 0")
+		}
+
 		memoryUsed := CalculateDockerMemoryUsed(statsJSON.MemoryStats)
-		memUsedMetric, _ := metrics.NodeMemoryUsed.AsFlatValue(memoryUsed)
+		memUsedMetric, err := metrics.NodeMemoryUsed.AsFlatValue(int64(memoryUsed))
+		if err != nil {
+			return err
+		}
 		state.AddMetric(memUsedMetric)
 
-		memLimitMetric, _ := metrics.NodeMemoryTotal.AsFlatValue(statsJSON.MemoryStats.Limit)
+		memLimitMetric, err := metrics.NodeMemoryTotal.AsFlatValue(int64(statsJSON.MemoryStats.Limit))
+		if err != nil {
+			return err
+		}
 		state.AddMetric(memLimitMetric)
 
 		return nil


### PR DESCRIPTION
- Update DockerHardwareInfo collector to use container CPU limits

- Update GetSystemInfo to use same CPU limit logic

- Add proper error handling for metric creation