### PR TITLE
fix: increases the timeout of the heartbeat

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -337,7 +337,7 @@ func (a *CommonAgent) SendHeartbeat() error {
 	}
 
 	// Add a timeout context to avoid hanging
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	req, err := retryablehttp.NewRequestWithContext(ctx, "POST", a.ServerURLs.PostHeartbeat(), bytes.NewBuffer(jsonData))


### PR DESCRIPTION
The recent changes add a couple seconds to the loading of the backend. This is the difference between experiments passing or crashing.

I'm also happy with digging deeper into optimizing the loading of the backend instead.