### PR TITLE
add error reporting to backend API

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"time"
 
 	"github.com/dbtuneai/agent/pkg/agent"
 	"github.com/dbtuneai/agent/pkg/aiven"
@@ -141,6 +142,14 @@ func main() {
 			adapter, err = pgprem.CreateDefaultPostgreSQLAdapter()
 		}
 		if err != nil {
+			if adapter != nil {
+				errorPayload := agent.ErrorPayload{
+					ErrorMessage: "Failed to create adapter: " + err.Error(),
+					ErrorType:    "startup_error",
+					Timestamp:    time.Now().UTC().Format(time.RFC3339),
+				}
+				adapter.SendError(errorPayload)
+			}
 			log.Fatalf("Failed to create adapter: %v", err)
 		}
 	}

--- a/pkg/dbtune/urls.go
+++ b/pkg/dbtune/urls.go
@@ -80,3 +80,8 @@ func (s ServerURLs) GetKnobRecommendations() string {
 func (s ServerURLs) PostGuardrailSignal() string {
 	return fmt.Sprintf("%s/api/v1/databases/%s/guardrail", s.ServerUrl, s.DbID)
 }
+
+// PostError generates the URL for posting errors.
+func (s ServerURLs) PostError() string {
+	return fmt.Sprintf("%s/api/v1/databases/%s/errors", s.ServerUrl, s.DbID)
+}

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -86,6 +86,11 @@ func (m *MockAgentLooper) SendGuardrailSignal(signal guardrails.Signal) error {
 	return args.Error(0)
 }
 
+func (m *MockAgentLooper) SendError(payload agent.ErrorPayload) error {
+	args := m.Called(payload)
+	return args.Error(0)
+}
+
 // Test runWithTicker function
 func TestRunWithTicker(t *testing.T) {
 	logger := logrus.New()


### PR DESCRIPTION
This PR contains:
- Add PostError endpoint URL method
- Add typed ErrorPayload struct to AgentLooper interface  
- Report config application errors to backend
- Report system info collection errors to backend
- Report startup/adapter creation errors to backend

 Still need the backend implementation before we merge this. 
 We can add more specific error report.