### PR TITLE
fix: udpate pgss limit to go from 100 to 500

### DIFF
--- a/pkg/internal/utils/query_runtime.go
+++ b/pkg/internal/utils/query_runtime.go
@@ -4,7 +4,7 @@ import (
 	"sort"
 )
 
-var diffLimit = 100
+var diffLimit = 500
 
 type CachedPGStatStatement struct {
 	QueryID       string  `json:"query_id"`


### PR DESCRIPTION
We now send the top 500 pg_stat_statements instead of top 100.