### PR TITLE
New installation steps for AWS ECS Fargate

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,24 +20,17 @@ The DBtune agent is a lightweight, extensible monitoring and configuration manag
 
 ## Quick start
 
-### Prerequisites
-
 There are multiple ways to run the DBtune agent:
 
-- Download and run the pre-built binary from the releases page
+- Download and run the pre-built binary
 - Use our official Docker image
 - Build from source (requires Go 1.23.1 or later)
+- AWS Fargate / ECS 
 
 ### Installation
 
-1. Download the latest release for your platform from our releases page or pull our Docker image:
-
-```bash
-docker pull public.ecr.aws/dbtune/dbtune/agent:latest
-```
-
-2. Configure your environment by creating a `dbtune.yaml` file (check the [configuration section](#configuration) for more details):
-
+Create a configuration file called `dbtune.yaml` file with the following contents (check the [configuration section](#configuration) for more details):
+	
 ```yaml
 debug: false
 postgresql:
@@ -50,46 +43,32 @@ dbtune:
   database_id: your-database-id
 ```
 
-3. Run the agent:
+This file will be used/referenced for the pre-built binary, docker and build from source installation methods.
 
-```bash
-./dbtune-agent  # If using binary
-# OR with Docker:
-# Example with mounted config file
-docker run -v $(pwd)/dbtune.yaml:/app/dbtune.yaml \
-    --name dbtune-agent \
-     public.ecr.aws/dbtune/dbtune/agent:latest
 
-# Example with environment variables
-docker run \
-  -e DBT_POSTGRESQL_CONNECTION_URL=postgresql://user:password@localhost:5432/database \
-  -e DBT_DBTUNE_SERVER_URL=https://app.dbtune.com \
-  -e DBT_DBTUNE_API_KEY=your-api-key \
-  -e DBT_DBTUNE_DATABASE_ID=your-database-id \
-  -e DBT_POSTGRESQL_INCLUDE_QUERIES=true \
-  public.ecr.aws/dbtune/dbtune/agent:latest
-```
-
-4. (Optional) Install a systemd service for dbtune-agent
-
-For the pre-built binary, create a systemd service with the following config and save it as `/etc/systemd/system/dbtune-agent.service`
-
-    [Unit]
-    Description=DBtune agent
-    After=network.target
-    
-    [Service]
-    User=dbtune   # User that runs the dbtune-agent, can be root
-    Group=dbtune  # Group to run the dbtune-agent with
-    WorkingDirectory=/usr/local/bin
-    ExecStart=/usr/local/bin/dbtune-agent
-    Restart=always
-    RestartSec=5s
-    StandardOutput=journal
-    StandardError=journal
-    
-    [Install]
-    WantedBy=multi-user.target
+#### Pre-built Binary
+1. Download the latest release for your platform from our [releases page](https://github.com/dbtuneai/dbtune-agent/releases)
+2. Run the agent via `./dbtune-agent` in a terminal where the binary was downloaded/expanded and your `dbtune.yaml` file exists.
+3. (Optional) Install a systemd service for dbtune-agent. Create a systemd service with the following config and save it as `/etc/systemd/system/dbtune-agent.service`.
+	
+	```
+	[Unit]
+	Description=DBtune agent
+	After=network.target
+	    
+	[Service]
+	User=dbtune   # User that runs the dbtune-agent, can be root
+	Group=dbtune  # Group to run the dbtune-agent with
+	WorkingDirectory=/usr/local/bin
+	ExecStart=/usr/local/bin/dbtune-agent
+	Restart=always
+	RestartSec=5s
+	StandardOutput=journal
+	StandardError=journal
+	    
+	[Install]
+	WantedBy=multi-user.target
+	```
 
 Make sure the user and group that you specify in the systemd service has rights to access postgres data files and also is allowed to use sudo without a password to do a systemd restart of the postgresql service e.g. `sudo systemctl restart postgres`.
 
@@ -100,6 +79,46 @@ sudo systemctl enable --now dbtune-agent
 ```
 
 Once started you can check and verify that the dbtune-agent is running by looking at the journal, for example: `journalctl -u dbtune-agent -f`
+
+
+#### Docker
+1. Pull our Docker image:
+
+	```
+	docker pull public.ecr.aws/dbtune/dbtune/agent:latest
+	```
+	
+2. Run the agent via `docker`
+ 	- With mounted config file
+
+		```
+		docker run -v $(pwd)/dbtune.yaml:/app/dbtune.yaml \
+		    --name dbtune-agent \
+		     public.ecr.aws/dbtune/dbtune/agent:latest
+		```
+ 	- With environment variables
+
+		```
+		docker run \
+			  -e DBT_POSTGRESQL_CONNECTION_URL=postgresql://user:password@localhost:5432/database \
+			  -e DBT_DBTUNE_SERVER_URL=https://app.dbtune.com \
+			  -e DBT_DBTUNE_API_KEY=your-api-key \
+			  -e DBT_DBTUNE_DATABASE_ID=your-database-id \
+			  -e DBT_POSTGRESQL_INCLUDE_QUERIES=true \
+			  public.ecr.aws/dbtune/dbtune/agent:latest
+
+		```
+	
+
+#### Build from source
+
+_DBTUNE TO ADD SPECIFIC STEPS HERE_
+
+
+#### AWS Fargate / ECS
+Follow these [README](fargate/README.md) instructions to run the agent under AWS Fargate as a service. 
+
+
 
 ## Configuration
 
@@ -203,3 +222,4 @@ The agent collects essential metrics required for DBtune's optimization engine, 
 ## License
 
 See github.com/dbtuneai/agent//blob/main/LICENSE
+``

--- a/fargate/README.md
+++ b/fargate/README.md
@@ -1,0 +1,145 @@
+# DBTune Setup and Configuration
+
+### Prerequisites
+These instructions require that you have the AWS cli v2 installed and your `~/.aws/credentials` file configured for your AWS account. [AWS CLI Install Instructions.](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
+
+
+##These commands are a one-time setup.
+
+###Prerequisites 
+
+Gather the following information that will be specific to your deployment. Examples are provided in parenthesis.
+
+- AWS\_ACCOUNT\_ID (`123445543331`)
+- AWS_REGION (`us-east-1`)
+- AWS\_SECURITY\_GROUPS (`sg-1556ec70`) (should be a comma separated list if you have multiple, this is an array in the commands below)
+- AWS_SUBNETS (`subnet-55938821,subnet-27c9ed0f`) (should be a comma separated list if you have multiple, this is an array in the commands below)
+
+The actual values that pertain to your AWS account need to be replaced in the commands below that are denoted by the `${}` convention.
+
+
+### IAM Role and Policies
+
+```
+aws iam create-role --role-name dbTuneTaskRole \
+  --description "DBTune Agent ECS tasks" \
+  --assume-role-policy-document '{"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Principal": {"Service": "ecs-tasks.amazonaws.com"}, "Action": "sts:AssumeRole"}]}'
+
+aws iam attach-role-policy --role-name dbTuneTaskRole \
+  --policy-arn arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+
+aws iam put-role-policy --role-name dbTuneTaskRole \
+  --policy-name GetSSMPganalyzeParameters \
+  --policy-document '{"Statement":[{"Action": ["ssm:GetParameter", "ssm:GetParameters", "ssm:GetParametersByPath"], "Effect": "Allow", "Resource": "arn:aws:ssm:*:*:parameter/dbtune/*"}, {"Action": "kms:Decrypt", "Effect": "Allow", "Resource": "arn:aws:kms:*:*:*"}]}'
+
+aws iam attach-role-policy --role-name dbTuneTaskRole \
+  --policy-arn arn:aws:iam::${AWS_ACCOUNT_ID}:policy/DBTune
+```
+
+### Configuring the agent on Amazon ECS
+
+##### AWS SSM Configuration
+The namespace conventions used below for SSM parameter names can be changed to your organizations requirements. This example assumes an _environment_ of `staging`.
+
+```
+aws ssm put-parameter --name /global/dbtune/api_key --type SecureString --value "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+aws ssm put-parameter --name /staging/dbtune/postgres_connection_url --type SecureString --value "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+```
+
+#### ECS Cluster Creation
+
+```
+aws ecs create-cluster --cluster-name dbtune
+
+```
+
+---
+
+#### Register the ECS Task Definition and Create Log group
+
+**NOTE**: These commands are `environment` (or database) specific. If you are attempting to monitor multiple databases, you will need to run these commands for *each* database. This example represents a `staging` database.
+
+The input file `dbtune_task.json` also needs to be updated with the variable replacements that pertain to your AWS Account. Make sure to edit/save this file before running the next command.
+
+```
+aws ecs register-task-definition --cli-input-json file://dbtune_task.json --no-cli-pager
+aws logs create-log-group --log-group-name /ecs/dbtune/staging --no-cli-pager
+```
+
+**Launch as a Service:**
+
+```
+aws ecs create-service \
+	--cluster dbtune \
+	--service-name dbtune-fargate-staging \
+	--task-definition dbtune-fargate-staging \
+	--desired-count 1 \
+	--launch-type FARGATE \
+	--platform-version LATEST \
+	--network-configuration "awsvpcConfiguration={assignPublicIp=ENABLED,subnets=[${AWS_SUBNETS}],securityGroups=[${AWS_SECURITY_GROUPS}]}" \
+	--no-cli-pager
+```
+
+**Setup an alarm for monitoring**
+
+Add the EventBridge Rule
+
+```
+aws events put-rule --name "dbtune-fargate-staging" --event-pattern "{\"source\":[\"aws.ecs\"],\"detail-type\":[\"ECS Task State Change\"],\"detail\":{\"lastStatus\":[\"STOPPED\"],\"clusterArn\":[\"arn:aws:ecs:${AWS_REGION}:${AWS_ACCOUNT_ID}:cluster/dbtune\"]}}" --state "ENABLED" --description "Monitoring rule for ECS DBTune staging" --event-bus-name "default" --no-cli-pager
+```
+
+Add the Target for the Rule
+
+This command _assumes_ you have an SNS topic called `AlertDevopsEngineers`. Point this target rule to any SNS topic you want a message sent to that your team will get alerted for ECS task state changes.
+
+```
+aws events put-targets --rule dbtune-fargate-staging --targets "Id"="Target1","Arn"="arn:aws:sns:${AWS_REGION}:${AWS_ACCOUNT_ID}:AlertDevopsEngineers" --no-cli-pager
+```
+
+
+## Update an Existing Task Definition and Redeploy
+In the event that you need to change or fix an issue with the task definition, the following steps will allow you to update the ECS task definition and _update_ the service. 
+
+**NOTE:** After running these commands, you will have two tasks running as the original is shutting down, be patient and it will terminate on it's own. You may see some duplicate metrics being sent to DBTune for a very short period until the original terminates and the newly updated task is Running.
+
+
+- Update the task definition defined in the `dbtune_task.json` file.
+- Run `aws ecs register-task-definition --cli-input-json file://dbtune_task.json --no-cli-page`
+- Determine the **latest version** that gets provided in the output from the command in the previous step from the `taskDefinitionArn`
+- Run `aws ecs update-service --cluster dbtune --service dbtune-fargate-staging --task-definition dbtune-fargate-staging:4 --force-new-deployment`
+- Tail the logs (see below) and make sure you don't get any errors.
+
+## Obtain shell access to a container task
+
+Enable execute command for the service:
+```
+aws ecs update-service --cluster dbtune --service dbtune-fargate-staging --enable-execute-command --force-new-deployment
+```
+
+Obtain terminal shell to container:
+```
+aws ecs execute-command --cluster dbtune \
+    --task ${ECS_TASK_ARN} \
+    --container dbtune \
+    --interactive \
+    --command "/bin/sh" \
+    --region ${AWS_REGION}
+```
+
+
+### ECS CLI Commands
+
+List ECS Clusters
+
+```
+aws ecs list-clusters
+
+aws ecs list-tasks --cluster dbtune
+
+```
+
+##### Log Monitoring
+
+```
+aws logs tail --follow /ecs/dbtune/staging
+```

--- a/fargate/dbtune_task.json
+++ b/fargate/dbtune_task.json
@@ -1,0 +1,40 @@
+{
+  "family": "dbtune-fargate-staging",
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "executionRoleArn": "arn:aws:iam::${AWS_ACCOUNT_ID}:role/dbTuneTaskRole",
+  "taskRoleArn": "arn:aws:iam::${AWS_ACCOUNT_ID}:role/dbTuneTaskRole",
+  "networkMode": "awsvpc",
+  "memory": "1024",
+  "cpu": "256",
+  "containerDefinitions": [
+    {
+      "name": "dbtune",
+      "image": "public.ecr.aws/dbtune/dbtune/agent:latest",
+      "command": ["--rds"],
+      "essential": true,
+      "environment": [
+        {"name": "DBT_RDS_DATABASE_IDENTIFIER", "value": "staging"},
+        {"name": "DBT_RDS_PARAMETER_GROUP_NAME", "value": "${PARAMETER_GROUP_NAME_ASSIGNED_TO_YOUR_RDS_DATABASE}"},
+        {"name": "DBT_AWS_REGION", "value": "${AWS_REGION}"},
+        {"name": "DBT_DBTUNE_SERVER_URL", "value": "https://app.dbtune.com"},
+        {"name": "DBT_DBTUNE_DATABASE_ID", "value": "${YOUR_DBTUNE_DATABASE_ID_PROVIDED_BY_DBTUNE}"}
+      ],
+      "secrets": [
+        {"name": "DBT_DBTUNE_API_KEY", "valueFrom": "/global/dbtune/api_key"},
+        {"name": "DBT_POSTGRESQL_CONNECTION_URL", "valueFrom": "/staging/dbtune/postgres_connection_url"}
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/dbtune/staging",
+          "awslogs-region": "us-east-1",
+          "awslogs-stream-prefix": "dbtune"
+        }
+      },
+      "readonlyRootFilesystem": false,
+      "mountPoints": []
+    }
+  ]
+}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [X] Documentation Update

## Description
This PR provides a new DBTune agent installation under AWS ECS Fargate. I rearranged the repository README to separate out installation methods and there IS a placeholder for the DBTune team to add installation steps for "Build from Source", see placeholder `DBTUNE TO ADD SPECIFIC STEPS HERE`. 

A separate README encapsulates the instructions for ECS Fargate since the steps are a bit verbose. A future enhancement for this would be to deploy this under Terraform.

Feedback welcome.