### PR TITLE
feat: add additional autovacuum metrics

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -257,7 +257,9 @@ type Caches struct {
 	PGWAL          PGWAL
 	PGCheckPointer PGCheckPointer
 
-	PGUserTables map[string]utils.PGUserTables
+	PGUserTables         map[string]utils.PGUserTables
+	PGClass              map[string]utils.PGClass
+	PGStatProgressVacuum map[string]utils.PGStatProgressVacuum
 
 	// Hardware specific cache for guardrails
 	// {

--- a/pkg/aiven/adapter.go
+++ b/pkg/aiven/adapter.go
@@ -413,8 +413,16 @@ func AivenCollectors(adapter *AivenPostgreSQLAdapter) []agent.MetricCollector {
 			Collector: pg.PGStatUserTables(pgDriver),
 		},
 		{
-			Key:       "pg_bgwriter",
-			Collector: pg.PGStatBGwriter(pgDriver),
+			Key:        "pg_class",
+			Collector:  pg.PGClass(pgDriver),
+		},
+		{
+			Key:        "pg_stat_progress_vacuum",
+			Collector:  pg.PGStatProgressVacuum(pgDriver),
+		},
+		{
+			Key:        "pg_bgwriter",
+			Collector:  pg.PGStatBGwriter(pgDriver),
 		},
 		{
 			Key:       "pg_wal",

--- a/pkg/aiven/adapter.go
+++ b/pkg/aiven/adapter.go
@@ -413,16 +413,20 @@ func AivenCollectors(adapter *AivenPostgreSQLAdapter) []agent.MetricCollector {
 			Collector: pg.PGStatUserTables(pgDriver),
 		},
 		{
-			Key:        "pg_class",
-			Collector:  pg.PGClass(pgDriver),
+			Key:       "pg_class",
+			Collector: pg.PGClass(pgDriver),
 		},
 		{
-			Key:        "pg_stat_progress_vacuum",
-			Collector:  pg.PGStatProgressVacuum(pgDriver),
+			Key:       "pg_stat_progress_vacuum",
+			Collector: pg.PGStatProgressVacuum(pgDriver),
 		},
 		{
-			Key:        "pg_bgwriter",
-			Collector:  pg.PGStatBGwriter(pgDriver),
+			Key:       "pg_old_transactions",
+			Collector: pg.PGOldTransactions(pgDriver),
+		},
+		{
+			Key:       "pg_bgwriter",
+			Collector: pg.PGStatBGwriter(pgDriver),
 		},
 		{
 			Key:       "pg_wal",

--- a/pkg/azureflex/adapter.go
+++ b/pkg/azureflex/adapter.go
@@ -339,8 +339,16 @@ func (adapter *AzureFlexAdapter) Collectors() []agent.MetricCollector {
 			Collector: pg.PGStatUserTables(pool),
 		},
 		{
-			Key:       "pg_bgwriter",
-			Collector: pg.PGStatBGwriter(pool),
+			Key:        "pg_class",
+			Collector:  pg.PGClass(pool),
+		},
+		{
+			Key:        "pg_stat_progress_vacuum",
+			Collector:  pg.PGStatProgressVacuum(pool),
+		},
+		{
+			Key:        "pg_bgwriter",
+			Collector:  pg.PGStatBGwriter(pool),
 		},
 		{
 			Key:       "pg_wal",

--- a/pkg/azureflex/adapter.go
+++ b/pkg/azureflex/adapter.go
@@ -339,16 +339,20 @@ func (adapter *AzureFlexAdapter) Collectors() []agent.MetricCollector {
 			Collector: pg.PGStatUserTables(pool),
 		},
 		{
-			Key:        "pg_class",
-			Collector:  pg.PGClass(pool),
+			Key:       "pg_class",
+			Collector: pg.PGClass(pool),
 		},
 		{
-			Key:        "pg_stat_progress_vacuum",
-			Collector:  pg.PGStatProgressVacuum(pool),
+			Key:       "pg_stat_progress_vacuum",
+			Collector: pg.PGStatProgressVacuum(pool),
 		},
 		{
-			Key:        "pg_bgwriter",
-			Collector:  pg.PGStatBGwriter(pool),
+			Key:       "pg_old_transactions",
+			Collector: pg.PGOldTransactions(pool),
+		},
+		{
+			Key:       "pg_bgwriter",
+			Collector: pg.PGStatBGwriter(pool),
 		},
 		{
 			Key:       "pg_wal",

--- a/pkg/cloudsql/adapter.go
+++ b/pkg/cloudsql/adapter.go
@@ -279,16 +279,20 @@ func (adapter *CloudSQLAdapter) Collectors() []agent.MetricCollector {
 			Collector: pg.PGStatUserTables(pool),
 		},
 		{
-			Key:        "pg_class",
-			Collector:  pg.PGClass(pool),
+			Key:       "pg_class",
+			Collector: pg.PGClass(pool),
 		},
 		{
-			Key:        "pg_stat_progress_vacuum",
-			Collector:  pg.PGStatProgressVacuum(pool),
+			Key:       "pg_stat_progress_vacuum",
+			Collector: pg.PGStatProgressVacuum(pool),
 		},
 		{
-			Key:        "pg_bgwriter",
-			Collector:  pg.PGStatBGwriter(pool),
+			Key:       "pg_old_transactions",
+			Collector: pg.PGOldTransactions(pool),
+		},
+		{
+			Key:       "pg_bgwriter",
+			Collector: pg.PGStatBGwriter(pool),
 		},
 		{
 			Key:       "pg_wal",

--- a/pkg/cloudsql/adapter.go
+++ b/pkg/cloudsql/adapter.go
@@ -279,8 +279,16 @@ func (adapter *CloudSQLAdapter) Collectors() []agent.MetricCollector {
 			Collector: pg.PGStatUserTables(pool),
 		},
 		{
-			Key:       "pg_bgwriter",
-			Collector: pg.PGStatBGwriter(pool),
+			Key:        "pg_class",
+			Collector:  pg.PGClass(pool),
+		},
+		{
+			Key:        "pg_stat_progress_vacuum",
+			Collector:  pg.PGStatProgressVacuum(pool),
+		},
+		{
+			Key:        "pg_bgwriter",
+			Collector:  pg.PGStatBGwriter(pool),
 		},
 		{
 			Key:       "pg_wal",

--- a/pkg/docker/adapter.go
+++ b/pkg/docker/adapter.go
@@ -117,16 +117,20 @@ func DockerCollectors(adapter *DockerContainerAdapter) []agent.MetricCollector {
 			Collector: pg.PGStatUserTables(pgDriver),
 		},
 		{
-			Key:        "pg_class",
-			Collector:  pg.PGClass(pgDriver),
+			Key:       "pg_class",
+			Collector: pg.PGClass(pgDriver),
 		},
 		{
-			Key:        "pg_stat_progress_vacuum",
-			Collector:  pg.PGStatProgressVacuum(pgDriver),
+			Key:       "pg_stat_progress_vacuum",
+			Collector: pg.PGStatProgressVacuum(pgDriver),
 		},
 		{
-			Key:        "pg_bgwriter",
-			Collector:  pg.PGStatBGwriter(pgDriver),
+			Key:       "pg_old_transactions",
+			Collector: pg.PGOldTransactions(pgDriver),
+		},
+		{
+			Key:       "pg_bgwriter",
+			Collector: pg.PGStatBGwriter(pgDriver),
 		},
 		{
 			Key:       "pg_wal",

--- a/pkg/docker/adapter.go
+++ b/pkg/docker/adapter.go
@@ -117,8 +117,16 @@ func DockerCollectors(adapter *DockerContainerAdapter) []agent.MetricCollector {
 			Collector: pg.PGStatUserTables(pgDriver),
 		},
 		{
-			Key:       "pg_bgwriter",
-			Collector: pg.PGStatBGwriter(pgDriver),
+			Key:        "pg_class",
+			Collector:  pg.PGClass(pgDriver),
+		},
+		{
+			Key:        "pg_stat_progress_vacuum",
+			Collector:  pg.PGStatProgressVacuum(pgDriver),
+		},
+		{
+			Key:        "pg_bgwriter",
+			Collector:  pg.PGStatBGwriter(pgDriver),
 		},
 		{
 			Key:       "pg_wal",

--- a/pkg/internal/utils/table_stats.go
+++ b/pkg/internal/utils/table_stats.go
@@ -18,3 +18,17 @@ type PGUserTables struct {
 	IdxScan          int64     `json:"idx_scan"`
 	IdxTupFetch      int64     `json:"idx_tup_fetch"`
 }
+
+type PGClass struct {
+	UnfrozenAge     int64 `json:"unfrozen_age"`
+	UnfrozenMXIDAge int64 `json:"unfrozen_mxid_age"`
+	RelAllVisible   int64 `json:"relallvisible"`
+}
+
+type PGStatProgressVacuum struct {
+	Phase            int64 `json:"phase"`
+	HeapBlksTotal    int64 `json:"heap_blks_total"`
+	HeapBlksScanned  int64 `json:"heap_blks_scanned"`
+	HeapBlksVacuumed int64 `json:"heap_blks_vacuumed"`
+	IndexVacuumCount int64 `json:"index_vacuum_count"`
+}

--- a/pkg/internal/utils/table_stats.go
+++ b/pkg/internal/utils/table_stats.go
@@ -3,32 +3,32 @@ package utils
 import "time"
 
 type PGUserTables struct {
-	Name             string    `json:"name"`
-	Oid              string    `json:"oid"`
-	LastAutoVacuum   time.Time `json:"last_autovacuum"`
-	LastAutoAnalyze  time.Time `json:"last_autoanalyze"`
-	AutoVacuumCount  int64     `json:"autovacuum_count"`
-	AutoAnalyzeCount int64     `json:"autoanalyze_count"`
-	NLiveTup         int64     `json:"n_live_tup"`
-	NDeadTup         int64     `json:"n_dead_tup"`
-	NModSinceAnalyze int64     `json:"n_mod_since_analyze"`
-	NInsSinceVacuum  int64     `json:"n_ins_since_vacuum"`
-	SeqScan          int64     `json:"seq_scan"`
-	SeqTupRead       int64     `json:"seq_tup_read"`
-	IdxScan          int64     `json:"idx_scan"`
-	IdxTupFetch      int64     `json:"idx_tup_fetch"`
+	Name             string
+	Relid            uint32
+	LastAutoVacuum   time.Time
+	LastAutoAnalyze  time.Time
+	AutoVacuumCount  int64
+	AutoAnalyzeCount int64
+	NLiveTup         int64
+	NDeadTup         int64
+	NModSinceAnalyze int64
+	NInsSinceVacuum  int64
+	SeqScan          int64
+	SeqTupRead       int64
+	IdxScan          int64
+	IdxTupFetch      int64
 }
 
 type PGClass struct {
-	UnfrozenAge     int64 `json:"unfrozen_age"`
-	UnfrozenMXIDAge int64 `json:"unfrozen_mxid_age"`
-	RelAllVisible   int64 `json:"relallvisible"`
+	UnfrozenAge     int64
+	UnfrozenMXIDAge int64
+	RelAllVisible   int64
 }
 
 type PGStatProgressVacuum struct {
-	Phase            int64 `json:"phase"`
-	HeapBlksTotal    int64 `json:"heap_blks_total"`
-	HeapBlksScanned  int64 `json:"heap_blks_scanned"`
-	HeapBlksVacuumed int64 `json:"heap_blks_vacuumed"`
-	IndexVacuumCount int64 `json:"index_vacuum_count"`
+	Phase            int64
+	HeapBlksTotal    int64
+	HeapBlksScanned  int64
+	HeapBlksVacuumed int64
+	IndexVacuumCount int64
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -267,6 +267,18 @@ var (
 	PGIdxTupFetch = MetricDef{Key: "pg_idx_tup_fetch", Type: IntMap}
 
 	// BG writing
+	// pg_class metrics
+	PGUnfrozenAge     = MetricDef{Key: "pg_unfrozen_age", Type: IntMap}
+	PGUnfrozenMXIDAge = MetricDef{Key: "pg_unfrozen_mxid_age", Type: IntMap}
+	PGRelAllVisible   = MetricDef{Key: "pg_relallvisible", Type: IntMap}
+
+	// pg_stat_progress_vacuum metrics
+	PGVacuumPhase            = MetricDef{Key: "pg_vacuum_phase", Type: IntMap}
+	PGVacuumHeapBlksTotal    = MetricDef{Key: "pg_vacuum_heap_blks_total", Type: IntMap}
+	PGVacuumHeapBlksScanned  = MetricDef{Key: "pg_vacuum_heap_blks_scanned", Type: IntMap}
+	PGVacuumHeapBlksVacuumed = MetricDef{Key: "pg_vacuum_heap_blks_vacuumed", Type: IntMap}
+	PGVacuumIndexVacuumCount = MetricDef{Key: "pg_vacuum_index_vacuum_count", Type: IntMap}
+
 	PGBGWBuffersClean    = MetricDef{Key: "pg_bg_buffers_clean", Type: Int}
 	PGMBGWaxWrittenClean = MetricDef{Key: "pg_bg_max_written_clean", Type: Int}
 	PGBGWBuffersAlloc    = MetricDef{Key: "pg_bg_buffers_alloc", Type: Int}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -294,6 +294,13 @@ var (
 	PGWALBytes         = MetricDef{Key: "pg_wal_bytes", Type: Int}
 	PGWALBuffersFull   = MetricDef{Key: "pg_wal_buffers_full", Type: Int}
 
+	// Old transaction tracking metrics
+	PGOldestTransactionAge             = MetricDef{Key: "pg_oldest_transaction_age", Type: IntMap}
+	PGOldestIdleTransactionAge         = MetricDef{Key: "pg_oldest_idle_transaction_age", Type: IntMap}
+	PGPreparedTransactionAge           = MetricDef{Key: "pg_prepared_transaction_age", Type: IntMap}
+	PGOldestReplicationSlotAge         = MetricDef{Key: "pg_oldest_replication_slot_age", Type: IntMap}
+	PGOldestInactiveReplicationSlotAge = MetricDef{Key: "pg_oldest_inactive_replication_slot_age", Type: IntMap}
+
 	// Performance
 	PerfAverageQueryRuntime   = MetricDef{Key: "perf_average_query_runtime", Type: Float}
 	PerfTransactionsPerSecond = MetricDef{Key: "perf_transactions_per_second", Type: Float}

--- a/pkg/pgprem/adapter.go
+++ b/pkg/pgprem/adapter.go
@@ -98,16 +98,20 @@ func DefaultCollectors(pgAdapter *DefaultPostgreSQLAdapter) []agent.MetricCollec
 			Collector: pg.PGStatUserTables(pgDriver),
 		},
 		{
-			Key:        "pg_class",
-			Collector:  pg.PGClass(pgDriver),
+			Key:       "pg_class",
+			Collector: pg.PGClass(pgDriver),
 		},
 		{
-			Key:        "pg_stat_progress_vacuum",
-			Collector:  pg.PGStatProgressVacuum(pgDriver),
+			Key:       "pg_stat_progress_vacuum",
+			Collector: pg.PGStatProgressVacuum(pgDriver),
 		},
 		{
-			Key:        "pg_bgwriter",
-			Collector:  pg.PGStatBGwriter(pgDriver),
+			Key:       "pg_old_transactions",
+			Collector: pg.PGOldTransactions(pgDriver),
+		},
+		{
+			Key:       "pg_bgwriter",
+			Collector: pg.PGStatBGwriter(pgDriver),
 		},
 		{
 			Key:       "pg_wal",

--- a/pkg/pgprem/adapter.go
+++ b/pkg/pgprem/adapter.go
@@ -98,8 +98,16 @@ func DefaultCollectors(pgAdapter *DefaultPostgreSQLAdapter) []agent.MetricCollec
 			Collector: pg.PGStatUserTables(pgDriver),
 		},
 		{
-			Key:       "pg_bgwriter",
-			Collector: pg.PGStatBGwriter(pgDriver),
+			Key:        "pg_class",
+			Collector:  pg.PGClass(pgDriver),
+		},
+		{
+			Key:        "pg_stat_progress_vacuum",
+			Collector:  pg.PGStatProgressVacuum(pgDriver),
+		},
+		{
+			Key:        "pg_bgwriter",
+			Collector:  pg.PGStatBGwriter(pgDriver),
 		},
 		{
 			Key:       "pg_wal",

--- a/pkg/rds/adapters.go
+++ b/pkg/rds/adapters.go
@@ -234,8 +234,16 @@ func (adapter *RDSAdapter) Collectors(aurora bool) []agent.MetricCollector {
 			Collector: pg.PGStatUserTables(pool),
 		},
 		{
-			Key:       "pg_bgwriter",
-			Collector: pg.PGStatBGwriter(pool),
+			Key:        "pg_class",
+			Collector:  pg.PGClass(pool),
+		},
+		{
+			Key:        "pg_stat_progress_vacuum",
+			Collector:  pg.PGStatProgressVacuum(pool),
+		},
+		{
+			Key:        "pg_bgwriter",
+			Collector:  pg.PGStatBGwriter(pool),
 		},
 		{
 			Key:       "database_wait_events",

--- a/pkg/rds/adapters.go
+++ b/pkg/rds/adapters.go
@@ -234,16 +234,20 @@ func (adapter *RDSAdapter) Collectors(aurora bool) []agent.MetricCollector {
 			Collector: pg.PGStatUserTables(pool),
 		},
 		{
-			Key:        "pg_class",
-			Collector:  pg.PGClass(pool),
+			Key:       "pg_class",
+			Collector: pg.PGClass(pool),
 		},
 		{
-			Key:        "pg_stat_progress_vacuum",
-			Collector:  pg.PGStatProgressVacuum(pool),
+			Key:       "pg_stat_progress_vacuum",
+			Collector: pg.PGStatProgressVacuum(pool),
 		},
 		{
-			Key:        "pg_bgwriter",
-			Collector:  pg.PGStatBGwriter(pool),
+			Key:       "pg_old_transactions",
+			Collector: pg.PGOldTransactions(pool),
+		},
+		{
+			Key:       "pg_bgwriter",
+			Collector: pg.PGStatBGwriter(pool),
 		},
 		{
 			Key:       "database_wait_events",


### PR DESCRIPTION
### Commit 1:
Adding the basic metrics from pg_stat_progress_vacuum and pg_class.

I skipped `dead_tuples_bytes` and `max_dead_tuples_bytes` cause I don't know if we need them and they are postgres 17+.

---
### Commit 2:
Are we allowed to store usernames or is that too sensitive. Maybe we should remove that?

--- 
## Testing and remaining work:
- I am not an expert on queries for replication etc. so we should probably test this out before releasing it to the public
- I think the backend needs to be updated to accept the new metrics