### PR TITLE
feat: add CollectedAt to collectors

### DIFF
--- a/pkg/pg/queries/collect.go
+++ b/pkg/pg/queries/collect.go
@@ -35,7 +35,8 @@ type PrepareCtx func(ctx context.Context) (context.Context, error)
 
 // Payload wraps a slice of rows collected from a catalog view.
 type Payload[T any] struct {
-	Rows []T `json:"rows"`
+	CollectedAt time.Time `json:"collected_at"`
+	Rows        []T       `json:"rows"`
 }
 
 // collectorOpts holds optional configuration for NewCollector.
@@ -130,6 +131,7 @@ func NewCollector[T any](
 			if err != nil {
 				return nil, err
 			}
+			collectedAt := time.Now().UTC()
 			querier := func() (pgx.Rows, error) {
 				return utils.QueryWithPrefix(pool, ctx, query)
 			}
@@ -137,12 +139,18 @@ func NewCollector[T any](
 			if err != nil {
 				return nil, err
 			}
-			data, err := json.Marshal(&Payload[T]{Rows: rows})
+			if cfg.skipUnchanged {
+				rowsData, err := json.Marshal(rows)
+				if err != nil {
+					return nil, fmt.Errorf("failed to marshal %s rows for hash: %w", name, err)
+				}
+				if tracker.shouldSkip(rowsData) {
+					return nil, nil
+				}
+			}
+			data, err := json.Marshal(&Payload[T]{CollectedAt: collectedAt, Rows: rows})
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal %s: %w", name, err)
-			}
-			if cfg.skipUnchanged && tracker.shouldSkip(data) {
-				return nil, nil
 			}
 			return &CollectResult{JSON: data}, nil
 		},

--- a/pkg/pg/queries/collectors_integration_test.go
+++ b/pkg/pg/queries/collectors_integration_test.go
@@ -766,8 +766,8 @@ func TestPgClass_BackfillThenDelta(t *testing.T) {
 		t.Fatal("expected non-zero collected_at on first backfill result")
 	}
 	// Verify row has non-empty identifiers.
-	if p1.Rows[0].SchemaName == "" || p1.Rows[0].RelName == "" {
-		t.Fatalf("expected non-empty schemaname/relname, got %q/%q", p1.Rows[0].SchemaName, p1.Rows[0].RelName)
+	if p1.Rows[0].SchemaName == "" || p1.Rows[0].Oid == 0 || p1.Rows[0].RelName == "" {
+		t.Fatalf("expected non-empty schemaname/oid/relname, got %q/%q/%q", p1.Rows[0].SchemaName, p1.Rows[0].Oid, p1.Rows[0].RelName)
 	}
 
 	// Drain the remaining backfill ticks until we get nil (backfill exhausted).

--- a/pkg/pg/queries/collectors_integration_test.go
+++ b/pkg/pg/queries/collectors_integration_test.go
@@ -262,6 +262,7 @@ func TestCollectors_AllVersions(t *testing.T) {
 					if r1.Hash() == "" {
 						t.Fatal("CollectResult.Hash() returned empty string")
 					}
+					requireCollectedAt(t, r1.JSON)
 
 					// Second call must not error — catches broken stateful collectors.
 					_, err = c.Collect(ctx)
@@ -383,6 +384,27 @@ func collectJSON(t *testing.T, c CatalogCollector) map[string]json.RawMessage {
 	return parsed
 }
 
+// requireCollectedAt verifies that the JSON payload contains a non-zero
+// "collected_at" timestamp.
+func requireCollectedAt(t *testing.T, data []byte) {
+	t.Helper()
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(data, &top); err != nil {
+		t.Fatalf("requireCollectedAt: failed to parse JSON: %v", err)
+	}
+	raw, ok := top["collected_at"]
+	if !ok {
+		t.Fatal("JSON missing 'collected_at' field")
+	}
+	var ts time.Time
+	if err := json.Unmarshal(raw, &ts); err != nil {
+		t.Fatalf("failed to parse collected_at as time: %v", err)
+	}
+	if ts.IsZero() {
+		t.Fatal("collected_at is zero")
+	}
+}
+
 // requireRows is a helper that parses the "rows" field from a collector result
 // and returns the count. Fails if rows is missing or empty.
 func requireRows(t *testing.T, c CatalogCollector) int {
@@ -452,6 +474,9 @@ func TestTransactionCommits_ComputesTPS(t *testing.T) {
 	if err := json.Unmarshal(r1.JSON, &p1); err != nil {
 		t.Fatalf("failed to parse first result: %v", err)
 	}
+	if p1.CollectedAt.IsZero() {
+		t.Fatal("expected non-zero collected_at on first call")
+	}
 	if p1.XactCommit <= 0 {
 		t.Fatalf("expected xact_commit > 0 on first call, got %d", p1.XactCommit)
 	}
@@ -476,6 +501,9 @@ func TestTransactionCommits_ComputesTPS(t *testing.T) {
 	var p2 TransactionCommitsPayload
 	if err := json.Unmarshal(r2.JSON, &p2); err != nil {
 		t.Fatalf("failed to parse second result: %v", err)
+	}
+	if p2.CollectedAt.IsZero() {
+		t.Fatal("expected non-zero collected_at on second call")
 	}
 	if p2.XactCommit < p1.XactCommit {
 		t.Fatalf("xact_commit decreased: %d → %d", p1.XactCommit, p2.XactCommit)
@@ -537,6 +565,9 @@ func TestPgStatioUserIndexes_BackfillThenDelta(t *testing.T) {
 	}
 	if len(p1.Rows) != 1 {
 		t.Fatalf("expected exactly 1 row with batch size 1, got %d", len(p1.Rows))
+	}
+	if p1.CollectedAt.IsZero() {
+		t.Fatal("expected non-zero collected_at on first backfill result")
 	}
 
 	// Drain the remaining backfill ticks until we get nil (backfill exhausted).
@@ -601,6 +632,9 @@ func TestPgStatioUserIndexes_DeltaEmitsOnlyChangedRows(t *testing.T) {
 	if backfillCount < 6 {
 		t.Fatalf("expected at least 6 backfill rows, got %d", backfillCount)
 	}
+	if p1.CollectedAt.IsZero() {
+		t.Fatal("expected non-zero collected_at on backfill result")
+	}
 
 	// Second call: empty page, transitions to delta mode.
 	r2, err := c.Collect(ctx)
@@ -634,6 +668,9 @@ func TestPgStatioUserIndexes_DeltaEmitsOnlyChangedRows(t *testing.T) {
 	var p3 Payload[PgStatioUserIndexesRow]
 	if err := json.Unmarshal(r3.JSON, &p3); err != nil {
 		t.Fatalf("failed to parse delta result: %v", err)
+	}
+	if p3.CollectedAt.IsZero() {
+		t.Fatal("expected non-zero collected_at on delta result")
 	}
 	if len(p3.Rows) == 0 {
 		t.Fatal("expected at least 1 changed row in delta")
@@ -725,6 +762,9 @@ func TestPgClass_BackfillThenDelta(t *testing.T) {
 	if len(p1.Rows) != 1 {
 		t.Fatalf("expected exactly 1 row with batch size 1, got %d", len(p1.Rows))
 	}
+	if p1.CollectedAt.IsZero() {
+		t.Fatal("expected non-zero collected_at on first backfill result")
+	}
 	// Verify row has non-empty identifiers.
 	if p1.Rows[0].SchemaName == "" || p1.Rows[0].RelName == "" {
 		t.Fatalf("expected non-empty schemaname/relname, got %q/%q", p1.Rows[0].SchemaName, p1.Rows[0].RelName)
@@ -784,6 +824,9 @@ func TestPgStats_BackfillThenDelta(t *testing.T) {
 	}
 	if len(p1.Rows) == 0 {
 		t.Fatal("expected non-empty pg_stats rows")
+	}
+	if p1.CollectedAt.IsZero() {
+		t.Fatal("expected non-zero collected_at on first backfill result")
 	}
 
 	// Verify rows have non-empty identifiers.
@@ -864,6 +907,9 @@ func TestPgStats_RedactsWhenIncludeTableDataFalse(t *testing.T) {
 		t.Fatalf("failed to parse JSON: %v", err)
 	}
 
+	if payload.CollectedAt.IsZero() {
+		t.Fatal("expected non-zero collected_at")
+	}
 	for _, row := range payload.Rows {
 		// After JSON round-trip, nil json.RawMessage becomes []byte("null").
 		if row.MostCommonVals != nil && string(row.MostCommonVals) != "null" {
@@ -909,6 +955,9 @@ func TestPgStatStatements_AllVersions(t *testing.T) {
 			if len(p1.Rows) == 0 {
 				t.Fatal("expected non-empty rows on first call")
 			}
+			if p1.CollectedAt.IsZero() {
+				t.Fatal("expected non-zero collected_at on first call")
+			}
 			if len(p1.Deltas) != 0 {
 				t.Fatalf("expected 0 deltas on first call, got %d", len(p1.Deltas))
 			}
@@ -936,6 +985,9 @@ func TestPgStatStatements_AllVersions(t *testing.T) {
 			var p2 PgStatStatementsPayload
 			if err := json.Unmarshal(r2.JSON, &p2); err != nil {
 				t.Fatalf("failed to parse second result: %v", err)
+			}
+			if p2.CollectedAt.IsZero() {
+				t.Fatal("expected non-zero collected_at on second call")
 			}
 			if p2.DeltaCount == 0 {
 				t.Fatal("expected delta_count > 0 on second call")

--- a/pkg/pg/queries/pg_class.go
+++ b/pkg/pg/queries/pg_class.go
@@ -26,6 +26,7 @@ const (
 
 // pgClassColumns is the SELECT list shared by batch and delta queries.
 const pgClassColumns = `
+	c.oid AS oid,
     n.nspname AS schemaname,
     c.relname,
     c.reltuples,
@@ -64,6 +65,7 @@ ORDER BY n.nspname, c.relname
 
 // PgClassRow represents a single row from pg_class for user tables.
 type PgClassRow struct {
+	Oid          Oid     `json:"oid"`
 	SchemaName   Name    `json:"schemaname"`
 	RelName      Name    `json:"relname"`
 	RelTuples    Real    `json:"reltuples"`

--- a/pkg/pg/queries/pg_class.go
+++ b/pkg/pg/queries/pg_class.go
@@ -96,6 +96,7 @@ func PgClassCollector(pool *pgxpool.Pool, prepareCtx PrepareCtx, cfg PgClassConf
 				return nil, err
 			}
 
+			collectedAt := time.Now().UTC()
 			var classRows []PgClassRow
 
 			if !backfillDone {
@@ -108,13 +109,11 @@ func PgClassCollector(pool *pgxpool.Pool, prepareCtx PrepareCtx, cfg PgClassConf
 				}
 				if len(classRows) == 0 {
 					backfillDone = true
-					lastPoll = time.Now().UTC()
+					lastPoll = collectedAt
 				} else {
 					backfillOffset += backfillBatchSize
 				}
 			} else {
-				now := time.Now().UTC()
-
 				querier := func() (pgx.Rows, error) {
 					return utils.QueryWithPrefix(pool, ctx, pgClassQueryDelta, lastPoll)
 				}
@@ -122,14 +121,14 @@ func PgClassCollector(pool *pgxpool.Pool, prepareCtx PrepareCtx, cfg PgClassConf
 				if err != nil {
 					return nil, err
 				}
-				lastPoll = now
+				lastPoll = collectedAt
 			}
 
 			if len(classRows) == 0 {
 				return nil, nil
 			}
 
-			data, err := json.Marshal(&Payload[PgClassRow]{Rows: classRows})
+			data, err := json.Marshal(&Payload[PgClassRow]{CollectedAt: collectedAt, Rows: classRows})
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal %s: %w", PgClassName, err)
 			}

--- a/pkg/pg/queries/pg_stat_statements.go
+++ b/pkg/pg/queries/pg_stat_statements.go
@@ -118,6 +118,7 @@ type PgStatStatementsDelta struct {
 
 // PgStatStatementsPayload is the JSON body POSTed to /api/v1/agent/pg_stat_statements.
 type PgStatStatementsPayload struct {
+	CollectedAt         time.Time               `json:"collected_at"`
 	Rows                []PgStatStatementsRow   `json:"rows"`
 	Deltas              []PgStatStatementsDelta `json:"deltas,omitempty"`
 	DeltaCount          int                     `json:"delta_count"`
@@ -349,6 +350,7 @@ func PgStatStatementsCollector(
 				return nil, err
 			}
 
+			collectedAt := time.Now().UTC()
 			detectedVersion, err := queryPGMajorVersion(pool, ctx)
 			if err != nil {
 				return nil, err
@@ -370,7 +372,8 @@ func PgStatStatementsCollector(
 			currSnapshot := toSnapshot(rows)
 
 			payload := &PgStatStatementsPayload{
-				Rows: rows,
+				CollectedAt: collectedAt,
+				Rows:        rows,
 			}
 
 			if prevSnapshot != nil {

--- a/pkg/pg/queries/pg_statio_user_indexes.go
+++ b/pkg/pg/queries/pg_statio_user_indexes.go
@@ -72,6 +72,7 @@ func PgStatioUserIndexesCollector(pool *pgxpool.Pool, prepareCtx PrepareCtx, cfg
 				return nil, err
 			}
 
+			collectedAt := time.Now().UTC()
 			rows, err := utils.QueryWithPrefix(pool, ctx, pgStatioUserIndexesQuery, batchSize, offset)
 			if err != nil {
 				return nil, fmt.Errorf("failed to query %s: %w", PgStatioUserIndexesName, err)
@@ -129,7 +130,7 @@ func PgStatioUserIndexesCollector(pool *pgxpool.Pool, prepareCtx PrepareCtx, cfg
 				return nil, nil
 			}
 
-			data, err := json.Marshal(&Payload[PgStatioUserIndexesRow]{Rows: emit})
+			data, err := json.Marshal(&Payload[PgStatioUserIndexesRow]{CollectedAt: collectedAt, Rows: emit})
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal %s: %w", PgStatioUserIndexesName, err)
 			}

--- a/pkg/pg/queries/pg_stats.go
+++ b/pkg/pg/queries/pg_stats.go
@@ -227,6 +227,7 @@ func PgStatsCollector(pool *pgxpool.Pool, prepareCtx PrepareCtx, cfg PgStatsConf
 				return nil, err
 			}
 
+			collectedAt := time.Now().UTC()
 			var statsRows []PgStatsRow
 
 			if !backfillDone {
@@ -236,24 +237,23 @@ func PgStatsCollector(pool *pgxpool.Pool, prepareCtx PrepareCtx, cfg PgStatsConf
 				}
 				if len(statsRows) == 0 {
 					backfillDone = true
-					lastPoll = time.Now().UTC()
+					lastPoll = collectedAt
 				} else {
 					backfillOffset += cfg.BackfillBatchSize
 				}
 			} else {
-				now := time.Now().UTC()
 				statsRows, err = collectPgStatsRows(pool, ctx, deltaQuery, lastPoll)
 				if err != nil {
 					return nil, err
 				}
-				lastPoll = now
+				lastPoll = collectedAt
 			}
 
 			if len(statsRows) == 0 {
 				return nil, nil
 			}
 
-			data, err := json.Marshal(&Payload[PgStatsRow]{Rows: statsRows})
+			data, err := json.Marshal(&Payload[PgStatsRow]{CollectedAt: collectedAt, Rows: statsRows})
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal %s: %w", PgStatsName, err)
 			}

--- a/pkg/pg/queries/transactions.go
+++ b/pkg/pg/queries/transactions.go
@@ -25,8 +25,9 @@ SELECT SUM(xact_commit)::bigint AS server_xact_commits
 FROM pg_stat_database`
 
 type TransactionCommitsPayload struct {
-	XactCommit int64   `json:"xact_commit"`
-	TPS        float64 `json:"tps,omitempty"`
+	CollectedAt time.Time `json:"collected_at"`
+	XactCommit  int64     `json:"xact_commit"`
+	TPS         float64   `json:"tps,omitempty"`
 }
 
 func TransactionCommitsCollector(pool *pgxpool.Pool, prepareCtx PrepareCtx) CatalogCollector {
@@ -43,6 +44,7 @@ func TransactionCommitsCollector(pool *pgxpool.Pool, prepareCtx PrepareCtx) Cata
 			if err != nil {
 				return nil, err
 			}
+			collectedAt := time.Now().UTC()
 			var xactCommit int64
 			err = utils.QueryRowWithPrefix(pool, ctx, transactionCommitsQuery).Scan(&xactCommit)
 			if err != nil {
@@ -50,10 +52,11 @@ func TransactionCommitsCollector(pool *pgxpool.Pool, prepareCtx PrepareCtx) Cata
 			}
 
 			payload := TransactionCommitsPayload{
-				XactCommit: xactCommit,
+				CollectedAt: collectedAt,
+				XactCommit:  xactCommit,
 			}
 
-			now := time.Now()
+			now := collectedAt
 			if !prev.timestamp.IsZero() && xactCommit >= prev.count {
 				duration := now.Sub(prev.timestamp).Seconds()
 				if duration > 0 {


### PR DESCRIPTION
This adds CollectedAt to all the collectors. This timestamp can be used by the platform instead of arrival timestamp if we want later