### PR TITLE
fix: drop rows from deltas

### DIFF
--- a/pkg/pg/queries/collectors_integration_test.go
+++ b/pkg/pg/queries/collectors_integration_test.go
@@ -1026,9 +1026,6 @@ func TestPgStatStatements_AllVersions(t *testing.T) {
 				if d.TotalExecTime == nil || *d.TotalExecTime <= 0 {
 					t.Fatalf("delta[%d]: expected total_exec_time > 0", i)
 				}
-				if d.Rows == nil || *d.Rows <= 0 {
-					t.Fatalf("delta[%d]: expected rows > 0", i)
-				}
 			}
 		})
 	}

--- a/pkg/pg/queries/pg_stat_statements.go
+++ b/pkg/pg/queries/pg_stat_statements.go
@@ -113,7 +113,6 @@ type PgStatStatementsDelta struct {
 
 	Calls         *Bigint          `json:"calls" db:"calls"`
 	TotalExecTime *DoublePrecision `json:"total_exec_time" db:"total_exec_time"`
-	Rows          *Bigint          `json:"rows" db:"rows"`
 }
 
 // PgStatStatementsPayload is the JSON body POSTed to /api/v1/agent/pg_stat_statements.
@@ -241,11 +240,9 @@ func calculateStatementDeltas(prev, curr map[string]PgStatStatementsRow, diffLim
 
 		callsDiff := ptrDiff(zeroPtr(prevRow.Calls, exists), currRow.Calls)
 		execTimeDiff := ptrDiff(zeroPtr(prevRow.TotalExecTime, exists), currRow.TotalExecTime)
-		rowsDiff := ptrDiff(zeroPtr(prevRow.Rows, exists), currRow.Rows)
 
 		if callsDiff == nil || *callsDiff <= 0 ||
-			execTimeDiff == nil || *execTimeDiff <= 0 ||
-			rowsDiff == nil || *rowsDiff <= 0 {
+			execTimeDiff == nil || *execTimeDiff <= 0 {
 			continue
 		}
 
@@ -257,7 +254,6 @@ func calculateStatementDeltas(prev, curr map[string]PgStatStatementsRow, diffLim
 			QueryID:       currRow.QueryID,
 			Calls:         callsDiff,
 			TotalExecTime: execTimeDiff,
-			Rows:          rowsDiff,
 		})
 	}
 


### PR DESCRIPTION
Drop rows from deltas, as we currently don't use them and we can use the cumulative ones as necessary.

This caused us to unnecessarily drop diffs from no-op deletes and updates.