### PR TITLE
feat: adds a config and env variable for a restart script in `pgprem`

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ export DBT_DBTUNE_SERVER_URL="https://app.dbtune.com"
 export DBT_DBTUNE_API_KEY=""
 export DBT_DBTUNE_DATABASE_ID=""
 export DBT_POSTGRESQL_ALLOW_RESTART=false  # Set to true to allow PostgreSQL restarts
+export DBT_POSTGRESQL_USE_RESTART_COMMAND=false  # Set to true use a custom restart script.
 
 # Your database specific
 export DBT_POSTGRESQL_CONNECTION_URL=postgresql://user:password@localhost:5432/database
@@ -164,6 +165,31 @@ sudo systemctl enable --now dbtune-agent
 ```
 
 Once started you can check and verify that the dbtune-agent is running by looking at the journal, for example: `journalctl -u dbtune-agent -f`
+
+### Using a custom restart script
+
+As mentioned above, one can specify a custom restart script in case restarting the database
+can't be done through `systemctl`.
+
+To do so, you will need to export the following environment variable
+```bash
+export DBT_POSTGRESQL_USE_RESTART_COMMAND=true
+```
+Afterwards, the agent will use a script located in `/opt/dbtune-agent/restart.sh` which
+must be executable (i.e. `chmod +x`).
+
+The script must signal success with exit code `0` and failure with any non-zero exit code. Output on stdout/stderr is logged on failure but does not by itself indicate failure — many tools (including `pg_ctl`) write to stderr during normal operation.
+
+An example of such a restart script using `pg_ctl` instead of `systemctl`:
+```sh 
+#!/bin/bash
+set -eo pipefail
+
+# Restarts the database using pg_ctl, and a timeout of 10min.
+# Assumes PGDATA points to the data folder of postgres.
+exec gosu postgres pg_ctl restart -D "$PGDATA" -m fast -w -t 600
+```
+
 
 ### AWS Fargate / ECS
 Follow these [README](fargate/README.md) instructions to run the agent under AWS Fargate as a service.

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ export DBT_DBTUNE_SERVER_URL="https://app.dbtune.com"
 export DBT_DBTUNE_API_KEY=""
 export DBT_DBTUNE_DATABASE_ID=""
 export DBT_POSTGRESQL_ALLOW_RESTART=false  # Set to true to allow PostgreSQL restarts
+export DBT_POSTGRESQL_USE_RESTART_COMMAND=false  # Set to true use a custom restart script.
 
 # Your database specific
 export DBT_POSTGRESQL_CONNECTION_URL=postgresql://user:password@localhost:5432/database
@@ -177,6 +178,31 @@ sudo systemctl enable --now dbtune-agent
 ```
 
 Once started you can check and verify that the dbtune-agent is running by looking at the journal, for example: `journalctl -u dbtune-agent -f`
+
+### Using a custom restart script
+
+As mentioned above, one can specify a custom restart script in case restarting the database
+can't be done through `systemctl`.
+
+To do so, you will need to export the following environment variable
+```bash
+export DBT_POSTGRESQL_USE_RESTART_COMMAND=true
+```
+Afterwards, the agent will use a script located in `/opt/dbtune-agent/restart.sh` which
+must be executable (i.e. `chmod +x`).
+
+The script must signal success with exit code `0` and failure with any non-zero exit code. Output on stdout/stderr is logged on failure but does not by itself indicate failure — many tools (including `pg_ctl`) write to stderr during normal operation.
+
+An example of such a restart script using `pg_ctl` instead of `systemctl`:
+```sh 
+#!/bin/bash
+set -eo pipefail
+
+# Restarts the database using pg_ctl, and a timeout of 10min.
+# Assumes PGDATA points to the data folder of postgres.
+exec gosu postgres pg_ctl restart -D "$PGDATA" -m fast -w -t 600
+```
+
 
 ### AWS Fargate / ECS
 Follow these [README](fargate/README.md) instructions to run the agent under AWS Fargate as a service.

--- a/pkg/pg/config.go
+++ b/pkg/pg/config.go
@@ -15,6 +15,22 @@ const (
 // RestartScriptPath is the fixed location of the optional operator-provided
 // restart script. When UseRestartCommand is true, the agent executes this
 // script directly (no shell interpolation) instead of `systemctl restart`.
+//
+// Contract: the script MUST signal success with exit code 0 and failure with
+// any non-zero exit code. Output written to stdout/stderr is treated as
+// diagnostic only (logged on failure) and does not affect the success/failure
+// decision — many tools write to stderr during normal operation.
+//
+// Minimal example (/opt/dbtune-agent/restart.sh):
+//
+//	#!/bin/bash
+//	# Must exit 0 on success, non-zero on failure.
+//	set -eo pipefail
+//	# Assumes PGDATA points to the data folder of postgres.
+//	exec gosu postgres pg_ctl restart -D "$PGDATA" -m fast -w -t 600
+//
+// The file must be executable (chmod +x). Adjust the data directory (-D) and
+// the user running pg_ctl to match your deployment.
 const RestartScriptPath = "/opt/dbtune-agent/restart.sh"
 
 type Config struct {

--- a/pkg/pg/config.go
+++ b/pkg/pg/config.go
@@ -12,11 +12,16 @@ const (
 	DEFAULT_CONFIG_KEY = "postgresql"
 )
 
+// RestartScriptPath is the fixed location of the optional operator-provided
+// restart script. When UseRestartCommand is true, the agent executes this
+// script directly (no shell interpolation) instead of `systemctl restart`.
+const RestartScriptPath = "/opt/dbtune-agent/restart.sh"
+
 type Config struct {
-	ConnectionURL  string `mapstructure:"connection_url" validate:"required"`
-	ServiceName    string `mapstructure:"service_name"`    // TODO(eddie): Should be moved under pgprem, as it doesn't apply to all other PG providers
-	RestartCommand string `mapstructure:"restart_command"` // TODO(eddie): pgprem-only, same as ServiceName. Shell command executed via `sh -c`; takes precedence over ServiceName-based systemctl restart.
-	AllowRestart   bool   `mapstructure:"allow_restart"`
+	ConnectionURL     string `mapstructure:"connection_url" validate:"required"`
+	ServiceName       string `mapstructure:"service_name"` // TODO(eddie): Should be moved under pgprem, as it doesn't apply to all other PG providers
+	UseRestartCommand bool   `mapstructure:"use_restart_command"`
+	AllowRestart      bool   `mapstructure:"allow_restart"`
 }
 
 func ConfigFromViper(key *string) (Config, error) {
@@ -42,7 +47,7 @@ func ConfigFromViper(key *string) (Config, error) {
 
 	_ = dbtuneConfig.BindEnv("connection_url", "DBT_POSTGRESQL_CONNECTION_URL")
 	_ = dbtuneConfig.BindEnv("service_name", "DBT_POSTGRESQL_SERVICE_NAME")
-	_ = dbtuneConfig.BindEnv("restart_command", "DBT_POSTGRESQL_RESTART_COMMAND")
+	_ = dbtuneConfig.BindEnv("use_restart_command", "DBT_POSTGRESQL_USE_RESTART_COMMAND")
 	_ = dbtuneConfig.BindEnv("allow_restart", "DBT_POSTGRESQL_ALLOW_RESTART")
 
 	// Also bind on the global viper so dotted lookups like
@@ -54,6 +59,7 @@ func ConfigFromViper(key *string) (Config, error) {
 	_ = viper.BindEnv("postgresql.allow_restart", "DBT_POSTGRESQL_ALLOW_RESTART")
 
 	dbtuneConfig.SetDefault("allow_restart", false)
+	dbtuneConfig.SetDefault("use_restart_command", false)
 
 	var pgConfig Config
 

--- a/pkg/pg/config.go
+++ b/pkg/pg/config.go
@@ -13,9 +13,10 @@ const (
 )
 
 type Config struct {
-	ConnectionURL string `mapstructure:"connection_url" validate:"required"`
-	ServiceName   string `mapstructure:"service_name"` // TODO(eddie): Should be moved under pgprem, as it doesn't apply to all other PG providers
-	AllowRestart  bool   `mapstructure:"allow_restart"`
+	ConnectionURL  string `mapstructure:"connection_url" validate:"required"`
+	ServiceName    string `mapstructure:"service_name"`    // TODO(eddie): Should be moved under pgprem, as it doesn't apply to all other PG providers
+	RestartCommand string `mapstructure:"restart_command"` // TODO(eddie): pgprem-only, same as ServiceName. Shell command executed via `sh -c`; takes precedence over ServiceName-based systemctl restart.
+	AllowRestart   bool   `mapstructure:"allow_restart"`
 }
 
 func ConfigFromViper(key *string) (Config, error) {
@@ -41,6 +42,7 @@ func ConfigFromViper(key *string) (Config, error) {
 
 	_ = dbtuneConfig.BindEnv("connection_url", "DBT_POSTGRESQL_CONNECTION_URL")
 	_ = dbtuneConfig.BindEnv("service_name", "DBT_POSTGRESQL_SERVICE_NAME")
+	_ = dbtuneConfig.BindEnv("restart_command", "DBT_POSTGRESQL_RESTART_COMMAND")
 	_ = dbtuneConfig.BindEnv("allow_restart", "DBT_POSTGRESQL_ALLOW_RESTART")
 
 	// Also bind on the global viper so dotted lookups like

--- a/pkg/pg/config.go
+++ b/pkg/pg/config.go
@@ -13,11 +13,16 @@ const (
 	DEFAULT_CONFIG_KEY = "postgresql"
 )
 
+// RestartScriptPath is the fixed location of the optional operator-provided
+// restart script. When UseRestartCommand is true, the agent executes this
+// script directly (no shell interpolation) instead of `systemctl restart`.
+const RestartScriptPath = "/opt/dbtune-agent/restart.sh"
+
 type Config struct {
-	ConnectionURL  string `mapstructure:"connection_url" validate:"required"`
-	ServiceName    string `mapstructure:"service_name"`    // TODO(eddie): Should be moved under pgprem, as it doesn't apply to all other PG providers
-	RestartCommand string `mapstructure:"restart_command"` // TODO(eddie): pgprem-only, same as ServiceName. Shell command executed via `sh -c`; takes precedence over ServiceName-based systemctl restart.
-	AllowRestart   bool   `mapstructure:"allow_restart"`
+	ConnectionURL     string `mapstructure:"connection_url" validate:"required"`
+	ServiceName       string `mapstructure:"service_name"` // TODO(eddie): Should be moved under pgprem, as it doesn't apply to all other PG providers
+	UseRestartCommand bool   `mapstructure:"use_restart_command"`
+	AllowRestart      bool   `mapstructure:"allow_restart"`
 }
 
 func ConfigFromViper(key *string) (Config, error) {
@@ -43,7 +48,7 @@ func ConfigFromViper(key *string) (Config, error) {
 
 	_ = dbtuneConfig.BindEnv("connection_url", "DBT_POSTGRESQL_CONNECTION_URL")
 	_ = dbtuneConfig.BindEnv("service_name", "DBT_POSTGRESQL_SERVICE_NAME")
-	_ = dbtuneConfig.BindEnv("restart_command", "DBT_POSTGRESQL_RESTART_COMMAND")
+	_ = dbtuneConfig.BindEnv("use_restart_command", "DBT_POSTGRESQL_USE_RESTART_COMMAND")
 	_ = dbtuneConfig.BindEnv("allow_restart", "DBT_POSTGRESQL_ALLOW_RESTART")
 
 	// Also bind on the global viper so dotted lookups like
@@ -55,6 +60,7 @@ func ConfigFromViper(key *string) (Config, error) {
 	_ = viper.BindEnv("postgresql.allow_restart", "DBT_POSTGRESQL_ALLOW_RESTART")
 
 	dbtuneConfig.SetDefault("allow_restart", false)
+	dbtuneConfig.SetDefault("use_restart_command", false)
 
 	var pgConfig Config
 

--- a/pkg/pg/config.go
+++ b/pkg/pg/config.go
@@ -16,6 +16,22 @@ const (
 // RestartScriptPath is the fixed location of the optional operator-provided
 // restart script. When UseRestartCommand is true, the agent executes this
 // script directly (no shell interpolation) instead of `systemctl restart`.
+//
+// Contract: the script MUST signal success with exit code 0 and failure with
+// any non-zero exit code. Output written to stdout/stderr is treated as
+// diagnostic only (logged on failure) and does not affect the success/failure
+// decision — many tools write to stderr during normal operation.
+//
+// Minimal example (/opt/dbtune-agent/restart.sh):
+//
+//	#!/bin/bash
+//	# Must exit 0 on success, non-zero on failure.
+//	set -eo pipefail
+//	# Assumes PGDATA points to the data folder of postgres.
+//	exec gosu postgres pg_ctl restart -D "$PGDATA" -m fast -w -t 600
+//
+// The file must be executable (chmod +x). Adjust the data directory (-D) and
+// the user running pg_ctl to match your deployment.
 const RestartScriptPath = "/opt/dbtune-agent/restart.sh"
 
 type Config struct {

--- a/pkg/pg/config.go
+++ b/pkg/pg/config.go
@@ -14,9 +14,10 @@ const (
 )
 
 type Config struct {
-	ConnectionURL string `mapstructure:"connection_url" validate:"required"`
-	ServiceName   string `mapstructure:"service_name"` // TODO(eddie): Should be moved under pgprem, as it doesn't apply to all other PG providers
-	AllowRestart  bool   `mapstructure:"allow_restart"`
+	ConnectionURL  string `mapstructure:"connection_url" validate:"required"`
+	ServiceName    string `mapstructure:"service_name"`    // TODO(eddie): Should be moved under pgprem, as it doesn't apply to all other PG providers
+	RestartCommand string `mapstructure:"restart_command"` // TODO(eddie): pgprem-only, same as ServiceName. Shell command executed via `sh -c`; takes precedence over ServiceName-based systemctl restart.
+	AllowRestart   bool   `mapstructure:"allow_restart"`
 }
 
 func ConfigFromViper(key *string) (Config, error) {
@@ -42,6 +43,7 @@ func ConfigFromViper(key *string) (Config, error) {
 
 	_ = dbtuneConfig.BindEnv("connection_url", "DBT_POSTGRESQL_CONNECTION_URL")
 	_ = dbtuneConfig.BindEnv("service_name", "DBT_POSTGRESQL_SERVICE_NAME")
+	_ = dbtuneConfig.BindEnv("restart_command", "DBT_POSTGRESQL_RESTART_COMMAND")
 	_ = dbtuneConfig.BindEnv("allow_restart", "DBT_POSTGRESQL_ALLOW_RESTART")
 
 	// Also bind on the global viper so dotted lookups like

--- a/pkg/pgprem/CONFIG.md
+++ b/pkg/pgprem/CONFIG.md
@@ -2,10 +2,13 @@
 ```yaml
 postgresql:
   connection_url: postgresql://user:password@localhost:5432/database # Database connection string
-  service_name: "postgresql-17" # (required for restart unless `restart_command` is set) name of your database service running under systemctl
-  # restart_command: "/usr/local/bin/restart-pg.sh" # Optional shell command executed via `sh -c` to restart PostgreSQL. Takes precedence over `service_name` when set.
+  service_name: "postgresql-17" # (required for restart unless `use_restart_command` is true) name of your database service running under systemctl
+  # use_restart_command: false  # When true, restarts are performed by directly executing the script at
+                                # /opt/dbtune-agent/restart.sh (no shell interpolation). Takes precedence
+                                # over `service_name`. The script must exist and be executable by the agent.
   allow_restart: false  # Allow the agent to restart PostgreSQL. Defaults to false.
-                        # When true, at least one of `service_name` or `restart_command` must be set.
+                        # When true, either `service_name` must be set or `use_restart_command` must be true
+                        # (with /opt/dbtune-agent/restart.sh present).
 
 dbtune:
   server_url: https://app.dbtune.com # DBtune server endpoint
@@ -31,7 +34,7 @@ export DBT_DBTUNE_DATABASE_ID=your-database-id
 # Your database specific
 export DBT_POSTGRESQL_CONNECTION_URL=postgresql://user:password@localhost:5432/database
 export DBT_POSTGRESQL_SERVICE_NAME=
-# export DBT_POSTGRESQL_RESTART_COMMAND=  # Optional: shell command executed via `sh -c`. Takes precedence over SERVICE_NAME.
+# export DBT_POSTGRESQL_USE_RESTART_COMMAND=false  # When true, restarts execute /opt/dbtune-agent/restart.sh directly. Takes precedence over SERVICE_NAME.
 export DBT_POSTGRESQL_ALLOW_RESTART=false  # Set to true to allow PostgreSQL restarts.
-                                           # When true, at least one of SERVICE_NAME or RESTART_COMMAND must be set.
+                                           # When true, either SERVICE_NAME must be set or USE_RESTART_COMMAND must be true.
 ```

--- a/pkg/pgprem/CONFIG.md
+++ b/pkg/pgprem/CONFIG.md
@@ -2,8 +2,10 @@
 ```yaml
 postgresql:
   connection_url: postgresql://user:password@localhost:5432/database # Database connection string
-  service_name: "postgresql-17" # (required for restart) name of your database service running under systemctl
+  service_name: "postgresql-17" # (required for restart unless `restart_command` is set) name of your database service running under systemctl
+  # restart_command: "/usr/local/bin/restart-pg.sh" # Optional shell command executed via `sh -c` to restart PostgreSQL. Takes precedence over `service_name` when set.
   allow_restart: false  # Allow the agent to restart PostgreSQL. Defaults to false.
+                        # When true, at least one of `service_name` or `restart_command` must be set.
 
 dbtune:
   server_url: https://app.dbtune.com # DBtune server endpoint
@@ -29,5 +31,7 @@ export DBT_DBTUNE_DATABASE_ID=your-database-id
 # Your database specific
 export DBT_POSTGRESQL_CONNECTION_URL=postgresql://user:password@localhost:5432/database
 export DBT_POSTGRESQL_SERVICE_NAME=
-export DBT_POSTGRESQL_ALLOW_RESTART=false  # Set to true to allow PostgreSQL restarts
+# export DBT_POSTGRESQL_RESTART_COMMAND=  # Optional: shell command executed via `sh -c`. Takes precedence over SERVICE_NAME.
+export DBT_POSTGRESQL_ALLOW_RESTART=false  # Set to true to allow PostgreSQL restarts.
+                                           # When true, at least one of SERVICE_NAME or RESTART_COMMAND must be set.
 ```

--- a/pkg/pgprem/adapter.go
+++ b/pkg/pgprem/adapter.go
@@ -193,13 +193,20 @@ func (adapter *DefaultPostgreSQLAdapter) ApplyConfig(_ context.Context, proposed
 		if adapter.pgConfig.UseRestartCommand {
 			// Execute the operator-provided restart script directly (no shell
 			// interpolation). Path is fixed so we never exec an attacker-controlled string.
+			//
+			// Contract: the script MUST signal success with exit code 0 and failure
+			// with any non-zero exit code. Output written to stdout/stderr is treated
+			// as diagnostic only and does not affect the success/failure decision.
 			cmd := exec.Command(pg.RestartScriptPath) //nolint:gosec
 			output, err := cmd.CombinedOutput()
-			if err != nil {
-				adapter.Logger().Warnf("restart script output: %s", string(output))
-				return fmt.Errorf("failed to restart PostgreSQL via %s: %w", pg.RestartScriptPath, err)
+			exitCode := cmd.ProcessState.ExitCode() // -1 if the process never ran
+			if err != nil || exitCode != 0 {
+				adapter.Logger().Warnf("restart script %s exited with code %d; output: %s",
+					pg.RestartScriptPath, exitCode, string(output))
+				return fmt.Errorf("restart script %s failed (exit code %d): %w",
+					pg.RestartScriptPath, exitCode, err)
 			}
-			adapter.Logger().Warnf("Service restarted via %s.", pg.RestartScriptPath)
+			adapter.Logger().Warnf("Service restarted via %s (exit code 0).", pg.RestartScriptPath)
 		} else {
 			// Execute systemctl restart command if it fails try executing it with sudo
 			cmd := exec.Command("systemctl", "restart", adapter.pgConfig.ServiceName) //nolint:gosec // ServiceName is from trusted config

--- a/pkg/pgprem/adapter.go
+++ b/pkg/pgprem/adapter.go
@@ -3,6 +3,7 @@ package pgprem
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 
 	"github.com/dbtuneai/agent/pkg/agent"
@@ -37,11 +38,29 @@ func CreateDefaultPostgreSQLAdapter() (*DefaultPostgreSQLAdapter, error) {
 		return nil, err
 	}
 
-	if pgConfig.AllowRestart && pgConfig.ServiceName == "" && pgConfig.RestartCommand == "" {
+	if pgConfig.AllowRestart && pgConfig.ServiceName == "" && !pgConfig.UseRestartCommand {
 		return nil, fmt.Errorf(
-			"postgresql.allow_restart is true but neither postgresql.service_name nor postgresql.restart_command is configured; " +
-				"restarts would fail silently. Set one of them (env: DBT_POSTGRESQL_SERVICE_NAME or DBT_POSTGRESQL_RESTART_COMMAND)",
+			"postgresql.allow_restart is true but neither postgresql.service_name nor postgresql.use_restart_command is configured; " +
+				"restarts would fail silently. Set postgresql.service_name (env: DBT_POSTGRESQL_SERVICE_NAME) " +
+				"or set postgresql.use_restart_command=true (env: DBT_POSTGRESQL_USE_RESTART_COMMAND) and provide " +
+				pg.RestartScriptPath,
 		)
+	}
+
+	if pgConfig.UseRestartCommand {
+		info, err := os.Stat(pg.RestartScriptPath)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"postgresql.use_restart_command is true but %s is not accessible: %w",
+				pg.RestartScriptPath, err,
+			)
+		}
+		if info.IsDir() {
+			return nil, fmt.Errorf("%s is a directory, expected an executable file", pg.RestartScriptPath)
+		}
+		if info.Mode()&0o111 == 0 {
+			return nil, fmt.Errorf("%s is not executable (mode %s); chmod +x it", pg.RestartScriptPath, info.Mode())
+		}
 	}
 
 	dbpool, err := pgPool.New(context.Background(), pgConfig.ConnectionURL)
@@ -171,16 +190,16 @@ func (adapter *DefaultPostgreSQLAdapter) ApplyConfig(_ context.Context, proposed
 		}
 		adapter.Logger().Warn("Restarting service")
 
-		if adapter.pgConfig.RestartCommand != "" {
-			// Custom restart command takes precedence. Executed via `sh -c` so
-			// either a script path or a full command line works.
-			cmd := exec.Command("sh", "-c", adapter.pgConfig.RestartCommand) //nolint:gosec // RestartCommand is from trusted config
+		if adapter.pgConfig.UseRestartCommand {
+			// Execute the operator-provided restart script directly (no shell
+			// interpolation). Path is fixed so we never exec an attacker-controlled string.
+			cmd := exec.Command(pg.RestartScriptPath) //nolint:gosec
 			output, err := cmd.CombinedOutput()
 			if err != nil {
-				adapter.Logger().Warnf("restart command output: %s", string(output))
-				return fmt.Errorf("failed to restart PostgreSQL via restart_command: %w", err)
+				adapter.Logger().Warnf("restart script output: %s", string(output))
+				return fmt.Errorf("failed to restart PostgreSQL via %s: %w", pg.RestartScriptPath, err)
 			}
-			adapter.Logger().Warn("Service restarted via restart_command.")
+			adapter.Logger().Warnf("Service restarted via %s.", pg.RestartScriptPath)
 		} else {
 			// Execute systemctl restart command if it fails try executing it with sudo
 			cmd := exec.Command("systemctl", "restart", adapter.pgConfig.ServiceName) //nolint:gosec // ServiceName is from trusted config

--- a/pkg/pgprem/adapter.go
+++ b/pkg/pgprem/adapter.go
@@ -37,6 +37,13 @@ func CreateDefaultPostgreSQLAdapter() (*DefaultPostgreSQLAdapter, error) {
 		return nil, err
 	}
 
+	if pgConfig.AllowRestart && pgConfig.ServiceName == "" && pgConfig.RestartCommand == "" {
+		return nil, fmt.Errorf(
+			"postgresql.allow_restart is true but neither postgresql.service_name nor postgresql.restart_command is configured; " +
+				"restarts would fail silently. Set one of them (env: DBT_POSTGRESQL_SERVICE_NAME or DBT_POSTGRESQL_RESTART_COMMAND)",
+		)
+	}
+
 	dbpool, err := pgPool.New(context.Background(), pgConfig.ConnectionURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create PG driver: %w", err)
@@ -143,13 +150,6 @@ func (adapter *DefaultPostgreSQLAdapter) GetActiveConfig(ctx context.Context) (a
 func (adapter *DefaultPostgreSQLAdapter) ApplyConfig(_ context.Context, proposedConfig *agent.ProposedConfigResponse) error {
 	adapter.Logger().Infof("Applying Config: %s", proposedConfig.KnobApplication)
 
-	if proposedConfig.KnobApplication == "restart" {
-		// If service name is missing, skip
-		if adapter.pgConfig.ServiceName == "" {
-			return fmt.Errorf("service name not configured, skipping restarting and applying configuration")
-		}
-	}
-
 	parsedKnobs, err := parameters.ParseKnobConfigurations(proposedConfig)
 	if err != nil {
 		return err
@@ -169,20 +169,32 @@ func (adapter *DefaultPostgreSQLAdapter) ApplyConfig(_ context.Context, proposed
 				Message: "restart is not allowed in the agent",
 			}
 		}
-		// Restart the service
 		adapter.Logger().Warn("Restarting service")
-		// Execute systemctl restart command if it fails try executing it with sudo
-		cmd := exec.Command("systemctl", "restart", adapter.pgConfig.ServiceName) //nolint:gosec // ServiceName is from trusted config
-		if err := cmd.Run(); err != nil {
-			adapter.Logger().Warnf("failed to restart PostgreSQL service: %v. Trying with sudo...", err)
 
-			sudoCmd := exec.Command("sudo", "systemctl", "restart", adapter.pgConfig.ServiceName) //nolint:gosec // ServiceName is from trusted config
-			if sudoErr := sudoCmd.Run(); sudoErr != nil {
-				return fmt.Errorf("failed to restart PostgreSQL service with sudo: %w", sudoErr)
+		if adapter.pgConfig.RestartCommand != "" {
+			// Custom restart command takes precedence. Executed via `sh -c` so
+			// either a script path or a full command line works.
+			cmd := exec.Command("sh", "-c", adapter.pgConfig.RestartCommand) //nolint:gosec // RestartCommand is from trusted config
+			output, err := cmd.CombinedOutput()
+			if err != nil {
+				adapter.Logger().Warnf("restart command output: %s", string(output))
+				return fmt.Errorf("failed to restart PostgreSQL via restart_command: %w", err)
 			}
-			adapter.Logger().Warn("Service restarted using sudo.")
+			adapter.Logger().Warn("Service restarted via restart_command.")
 		} else {
-			adapter.Logger().Warn("Service restarted.")
+			// Execute systemctl restart command if it fails try executing it with sudo
+			cmd := exec.Command("systemctl", "restart", adapter.pgConfig.ServiceName) //nolint:gosec // ServiceName is from trusted config
+			if err := cmd.Run(); err != nil {
+				adapter.Logger().Warnf("failed to restart PostgreSQL service: %v. Trying with sudo...", err)
+
+				sudoCmd := exec.Command("sudo", "systemctl", "restart", adapter.pgConfig.ServiceName) //nolint:gosec // ServiceName is from trusted config
+				if sudoErr := sudoCmd.Run(); sudoErr != nil {
+					return fmt.Errorf("failed to restart PostgreSQL service with sudo: %w", sudoErr)
+				}
+				adapter.Logger().Warn("Service restarted using sudo.")
+			} else {
+				adapter.Logger().Warn("Service restarted.")
+			}
 		}
 
 		err := pg.WaitPostgresReady(adapter.pgDriver)

--- a/pkg/pgprem/adapter.go
+++ b/pkg/pgprem/adapter.go
@@ -40,8 +40,8 @@ func CreateDefaultPostgreSQLAdapter() (*DefaultPostgreSQLAdapter, error) {
 
 	if pgConfig.AllowRestart && pgConfig.ServiceName == "" && !pgConfig.UseRestartCommand {
 		return nil, fmt.Errorf(
-			"postgresql.allow_restart is true but neither postgresql.service_name nor postgresql.use_restart_command is configured; " +
-				"restarts would fail silently. Set postgresql.service_name (env: DBT_POSTGRESQL_SERVICE_NAME) " +
+			"postgresql.allow_restart is true but neither postgresql.service_name nor postgresql.use_restart_command is configured. " +
+				"Set postgresql.service_name (env: DBT_POSTGRESQL_SERVICE_NAME) " +
 				"or set postgresql.use_restart_command=true (env: DBT_POSTGRESQL_USE_RESTART_COMMAND) and provide " +
 				pg.RestartScriptPath,
 		)

--- a/pkg/pgprem/adapter.go
+++ b/pkg/pgprem/adapter.go
@@ -184,7 +184,7 @@ func (adapter *DefaultPostgreSQLAdapter) ApplyConfig(ctx context.Context, propos
 	if err != nil {
 		return &agent.ConfigApplyError{Err: err}
 	}
-	if requiresRestart && adapter.pgConfig.ServiceName == "" {
+	if requiresRestart && adapter.pgConfig.ServiceName == "" && !adapter.pgConfig.UseRestartCommand {
 		return &agent.ConfigApplyError{Err: fmt.Errorf("service name not configured, refusing to apply: a restart is required to take effect")}
 	}
 
@@ -195,66 +195,52 @@ func (adapter *DefaultPostgreSQLAdapter) ApplyConfig(ctx context.Context, propos
 		}
 	}
 
-	switch proposedConfig.KnobApplication {
-	case "restart":
-		if !agent.IsRestartAllowed() {
-			return &agent.RestartNotAllowedError{
-				Message: "restart is not allowed in the agent",
-			}
+	if !requiresRestart {
+		// No parameter actually needs a restart: reload, even if the
+		// proposed KnobApplication asked for restart.
+		if err := pg.ReloadConfig(adapter.pgDriver); err != nil {
+			return &agent.ConfigApplyError{Err: err}
 		}
-		adapter.Logger().Warn("Restarting service")
+		return nil
+	}
 
-		if adapter.pgConfig.UseRestartCommand {
-			// Execute the operator-provided restart script directly (no shell
-			// interpolation). Path is fixed so we never exec an attacker-controlled string.
-			//
-			// Contract: the script MUST signal success with exit code 0 and failure
-			// with any non-zero exit code. Output written to stdout/stderr is treated
-			// as diagnostic only and does not affect the success/failure decision.
-			cmd := exec.Command(pg.RestartScriptPath) //nolint:gosec
-			output, err := cmd.CombinedOutput()
-			exitCode := cmd.ProcessState.ExitCode() // -1 if the process never ran
-			if err != nil || exitCode != 0 {
-				adapter.Logger().Warnf("restart script %s exited with code %d; output: %s",
-					pg.RestartScriptPath, exitCode, string(output))
-				return &agent.ConfigApplyError{Err: fmt.Errorf("restart script %s failed (exit code %d): %w",
-					pg.RestartScriptPath, exitCode, err)}
+	adapter.Logger().Warn("Restarting service")
+
+	if adapter.pgConfig.UseRestartCommand {
+		// Execute the operator-provided restart script directly (no shell
+		// interpolation). Path is fixed so we never exec an attacker-controlled string.
+		//
+		// Contract: the script MUST signal success with exit code 0 and failure
+		// with any non-zero exit code. Output written to stdout/stderr is treated
+		// as diagnostic only and does not affect the success/failure decision.
+		cmd := exec.Command(pg.RestartScriptPath) //nolint:gosec
+		output, err := cmd.CombinedOutput()
+		exitCode := cmd.ProcessState.ExitCode() // -1 if the process never ran
+		if err != nil || exitCode != 0 {
+			adapter.Logger().Warnf("restart script %s exited with code %d; output: %s",
+				pg.RestartScriptPath, exitCode, string(output))
+			return &agent.ConfigApplyError{Err: fmt.Errorf("restart script %s failed (exit code %d): %w",
+				pg.RestartScriptPath, exitCode, err)}
+		}
+		adapter.Logger().Warnf("Service restarted via %s (exit code 0).", pg.RestartScriptPath)
+	} else {
+		// Execute systemctl restart command if it fails try executing it with sudo
+		cmd := exec.Command("systemctl", "restart", adapter.pgConfig.ServiceName) //nolint:gosec // ServiceName is from trusted config
+		if err := cmd.Run(); err != nil {
+			adapter.Logger().Warnf("failed to restart PostgreSQL service: %v. Trying with sudo...", err)
+
+			sudoCmd := exec.Command("sudo", "systemctl", "restart", adapter.pgConfig.ServiceName) //nolint:gosec // ServiceName is from trusted config
+			if sudoErr := sudoCmd.Run(); sudoErr != nil {
+				return &agent.ConfigApplyError{Err: fmt.Errorf("failed to restart PostgreSQL service with sudo: %w", sudoErr)}
 			}
-			adapter.Logger().Warnf("Service restarted via %s (exit code 0).", pg.RestartScriptPath)
+			adapter.Logger().Warn("Service restarted using sudo.")
 		} else {
-			// Execute systemctl restart command if it fails try executing it with sudo
-			cmd := exec.Command("systemctl", "restart", adapter.pgConfig.ServiceName) //nolint:gosec // ServiceName is from trusted config
-			if err := cmd.Run(); err != nil {
-				adapter.Logger().Warnf("failed to restart PostgreSQL service: %v. Trying with sudo...", err)
+			adapter.Logger().Warn("Service restarted.")
+		}
+	}
 
-				sudoCmd := exec.Command("sudo", "systemctl", "restart", adapter.pgConfig.ServiceName) //nolint:gosec // ServiceName is from trusted config
-				if sudoErr := sudoCmd.Run(); sudoErr != nil {
-					return &agent.ConfigApplyError{Err: fmt.Errorf("failed to restart PostgreSQL service with sudo: %w", sudoErr)}
-				}
-				adapter.Logger().Warn("Service restarted using sudo.")
-			} else {
-				adapter.Logger().Warn("Service restarted.")
-			}
-		}
-
-		err := pg.WaitPostgresReady(adapter.pgDriver)
-		if err != nil {
-			return &agent.ConfigApplyError{Err: fmt.Errorf("failed to wait for PostgreSQL to be back online: %w", err)}
-		}
-	case "reload":
-		// Reload database when everything is applied
-		err := pg.ReloadConfig(adapter.pgDriver)
-		if err != nil {
-			return &agent.ConfigApplyError{Err: err}
-		}
-	case "":
-		// TODO(eddie): We should make this more explicit somehow.
-		// This happens when nothing is sent from the backend about this.
-		// We should send an explicit string instead of leaving it blank.
-		err := pg.ReloadConfig(adapter.pgDriver)
-		if err != nil {
-			return &agent.ConfigApplyError{Err: err}
-		}
+	if err := pg.WaitPostgresReady(adapter.pgDriver); err != nil {
+		return &agent.ConfigApplyError{Err: fmt.Errorf("failed to wait for PostgreSQL to be back online: %w", err)}
 	}
 	return nil
 }

--- a/pkg/pgprem/adapter.go
+++ b/pkg/pgprem/adapter.go
@@ -3,6 +3,7 @@ package pgprem
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 
 	"github.com/dbtuneai/agent/pkg/agent"
@@ -37,11 +38,29 @@ func CreateDefaultPostgreSQLAdapter() (*DefaultPostgreSQLAdapter, error) {
 		return nil, err
 	}
 
-	if pgConfig.AllowRestart && pgConfig.ServiceName == "" && pgConfig.RestartCommand == "" {
+	if pgConfig.AllowRestart && pgConfig.ServiceName == "" && !pgConfig.UseRestartCommand {
 		return nil, fmt.Errorf(
-			"postgresql.allow_restart is true but neither postgresql.service_name nor postgresql.restart_command is configured; " +
-				"restarts would fail silently. Set one of them (env: DBT_POSTGRESQL_SERVICE_NAME or DBT_POSTGRESQL_RESTART_COMMAND)",
+			"postgresql.allow_restart is true but neither postgresql.service_name nor postgresql.use_restart_command is configured; " +
+				"restarts would fail silently. Set postgresql.service_name (env: DBT_POSTGRESQL_SERVICE_NAME) " +
+				"or set postgresql.use_restart_command=true (env: DBT_POSTGRESQL_USE_RESTART_COMMAND) and provide " +
+				pg.RestartScriptPath,
 		)
+	}
+
+	if pgConfig.UseRestartCommand {
+		info, err := os.Stat(pg.RestartScriptPath)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"postgresql.use_restart_command is true but %s is not accessible: %w",
+				pg.RestartScriptPath, err,
+			)
+		}
+		if info.IsDir() {
+			return nil, fmt.Errorf("%s is a directory, expected an executable file", pg.RestartScriptPath)
+		}
+		if info.Mode()&0o111 == 0 {
+			return nil, fmt.Errorf("%s is not executable (mode %s); chmod +x it", pg.RestartScriptPath, info.Mode())
+		}
 	}
 
 	dbpool, err := pgPool.New(context.Background(), pgConfig.ConnectionURL)
@@ -185,16 +204,16 @@ func (adapter *DefaultPostgreSQLAdapter) ApplyConfig(ctx context.Context, propos
 		}
 		adapter.Logger().Warn("Restarting service")
 
-		if adapter.pgConfig.RestartCommand != "" {
-			// Custom restart command takes precedence. Executed via `sh -c` so
-			// either a script path or a full command line works.
-			cmd := exec.Command("sh", "-c", adapter.pgConfig.RestartCommand) //nolint:gosec // RestartCommand is from trusted config
+		if adapter.pgConfig.UseRestartCommand {
+			// Execute the operator-provided restart script directly (no shell
+			// interpolation). Path is fixed so we never exec an attacker-controlled string.
+			cmd := exec.Command(pg.RestartScriptPath) //nolint:gosec
 			output, err := cmd.CombinedOutput()
 			if err != nil {
-				adapter.Logger().Warnf("restart command output: %s", string(output))
-				return &agent.ConfigApplyError{Err: fmt.Errorf("failed to restart PostgreSQL via restart_command: %w", err)}
+				adapter.Logger().Warnf("restart script output: %s", string(output))
+				return &agent.ConfigApplyError{Err: fmt.Errorf("failed to restart PostgreSQL via %s: %w", pg.RestartScriptPath, err)}
 			}
-			adapter.Logger().Warn("Service restarted via restart_command.")
+			adapter.Logger().Warnf("Service restarted via %s.", pg.RestartScriptPath)
 		} else {
 			// Execute systemctl restart command if it fails try executing it with sudo
 			cmd := exec.Command("systemctl", "restart", adapter.pgConfig.ServiceName) //nolint:gosec // ServiceName is from trusted config

--- a/pkg/pgprem/adapter.go
+++ b/pkg/pgprem/adapter.go
@@ -207,13 +207,20 @@ func (adapter *DefaultPostgreSQLAdapter) ApplyConfig(ctx context.Context, propos
 		if adapter.pgConfig.UseRestartCommand {
 			// Execute the operator-provided restart script directly (no shell
 			// interpolation). Path is fixed so we never exec an attacker-controlled string.
+			//
+			// Contract: the script MUST signal success with exit code 0 and failure
+			// with any non-zero exit code. Output written to stdout/stderr is treated
+			// as diagnostic only and does not affect the success/failure decision.
 			cmd := exec.Command(pg.RestartScriptPath) //nolint:gosec
 			output, err := cmd.CombinedOutput()
-			if err != nil {
-				adapter.Logger().Warnf("restart script output: %s", string(output))
-				return &agent.ConfigApplyError{Err: fmt.Errorf("failed to restart PostgreSQL via %s: %w", pg.RestartScriptPath, err)}
+			exitCode := cmd.ProcessState.ExitCode() // -1 if the process never ran
+			if err != nil || exitCode != 0 {
+				adapter.Logger().Warnf("restart script %s exited with code %d; output: %s",
+					pg.RestartScriptPath, exitCode, string(output))
+				return &agent.ConfigApplyError{Err: fmt.Errorf("restart script %s failed (exit code %d): %w",
+					pg.RestartScriptPath, exitCode, err)}
 			}
-			adapter.Logger().Warnf("Service restarted via %s.", pg.RestartScriptPath)
+			adapter.Logger().Warnf("Service restarted via %s (exit code 0).", pg.RestartScriptPath)
 		} else {
 			// Execute systemctl restart command if it fails try executing it with sudo
 			cmd := exec.Command("systemctl", "restart", adapter.pgConfig.ServiceName) //nolint:gosec // ServiceName is from trusted config

--- a/pkg/pgprem/adapter.go
+++ b/pkg/pgprem/adapter.go
@@ -37,6 +37,13 @@ func CreateDefaultPostgreSQLAdapter() (*DefaultPostgreSQLAdapter, error) {
 		return nil, err
 	}
 
+	if pgConfig.AllowRestart && pgConfig.ServiceName == "" && pgConfig.RestartCommand == "" {
+		return nil, fmt.Errorf(
+			"postgresql.allow_restart is true but neither postgresql.service_name nor postgresql.restart_command is configured; " +
+				"restarts would fail silently. Set one of them (env: DBT_POSTGRESQL_SERVICE_NAME or DBT_POSTGRESQL_RESTART_COMMAND)",
+		)
+	}
+
 	dbpool, err := pgPool.New(context.Background(), pgConfig.ConnectionURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create PG driver: %w", err)
@@ -169,31 +176,55 @@ func (adapter *DefaultPostgreSQLAdapter) ApplyConfig(ctx context.Context, propos
 		}
 	}
 
-	if requiresRestart {
-		// Restart the service
-		adapter.Logger().Warn("Restarting service")
-		// Execute systemctl restart command if it fails try executing it with sudo
-		cmd := exec.Command("systemctl", "restart", adapter.pgConfig.ServiceName) //nolint:gosec // ServiceName is from trusted config
-		if err := cmd.Run(); err != nil {
-			adapter.Logger().Warnf("failed to restart PostgreSQL service: %v. Trying with sudo...", err)
-
-			sudoCmd := exec.Command("sudo", "systemctl", "restart", adapter.pgConfig.ServiceName) //nolint:gosec // ServiceName is from trusted config
-			if sudoErr := sudoCmd.Run(); sudoErr != nil {
-				return &agent.ConfigApplyError{Err: fmt.Errorf("failed to restart PostgreSQL service with sudo: %w", sudoErr)}
+	switch proposedConfig.KnobApplication {
+	case "restart":
+		if !agent.IsRestartAllowed() {
+			return &agent.RestartNotAllowedError{
+				Message: "restart is not allowed in the agent",
 			}
-			adapter.Logger().Warn("Service restarted using sudo.")
+		}
+		adapter.Logger().Warn("Restarting service")
+
+		if adapter.pgConfig.RestartCommand != "" {
+			// Custom restart command takes precedence. Executed via `sh -c` so
+			// either a script path or a full command line works.
+			cmd := exec.Command("sh", "-c", adapter.pgConfig.RestartCommand) //nolint:gosec // RestartCommand is from trusted config
+			output, err := cmd.CombinedOutput()
+			if err != nil {
+				adapter.Logger().Warnf("restart command output: %s", string(output))
+				return &agent.ConfigApplyError{Err: fmt.Errorf("failed to restart PostgreSQL via restart_command: %w", err)}
+			}
+			adapter.Logger().Warn("Service restarted via restart_command.")
 		} else {
-			adapter.Logger().Warn("Service restarted.")
+			// Execute systemctl restart command if it fails try executing it with sudo
+			cmd := exec.Command("systemctl", "restart", adapter.pgConfig.ServiceName) //nolint:gosec // ServiceName is from trusted config
+			if err := cmd.Run(); err != nil {
+				adapter.Logger().Warnf("failed to restart PostgreSQL service: %v. Trying with sudo...", err)
+
+				sudoCmd := exec.Command("sudo", "systemctl", "restart", adapter.pgConfig.ServiceName) //nolint:gosec // ServiceName is from trusted config
+				if sudoErr := sudoCmd.Run(); sudoErr != nil {
+					return &agent.ConfigApplyError{Err: fmt.Errorf("failed to restart PostgreSQL service with sudo: %w", sudoErr)}
+				}
+				adapter.Logger().Warn("Service restarted using sudo.")
+			} else {
+				adapter.Logger().Warn("Service restarted.")
+			}
 		}
 
 		err := pg.WaitPostgresReady(adapter.pgDriver)
 		if err != nil {
 			return &agent.ConfigApplyError{Err: fmt.Errorf("failed to wait for PostgreSQL to be back online: %w", err)}
 		}
-	} else {
-		// Reload database when everything is applied. KnobApplication=restart
-		// with no postmaster-context params falls through here too: the intent
-		// is treated as a hint, and we avoid a needless restart.
+	case "reload":
+		// Reload database when everything is applied
+		err := pg.ReloadConfig(adapter.pgDriver)
+		if err != nil {
+			return &agent.ConfigApplyError{Err: err}
+		}
+	case "":
+		// TODO(eddie): We should make this more explicit somehow.
+		// This happens when nothing is sent from the backend about this.
+		// We should send an explicit string instead of leaving it blank.
 		err := pg.ReloadConfig(adapter.pgDriver)
 		if err != nil {
 			return &agent.ConfigApplyError{Err: err}


### PR DESCRIPTION
We currently always assume that `pgprem` should be restarted using `systemctl`. What if the user's set-up is more complex, and they require a different way of restarting?

This PR allows the user to specify a command for restarting `pg`. This command takes precedence over `service_name` if both are specified. If `allow_restarts` is True and none of them are set-up, we complain.