### PR TITLE
fix: gate pg_stat_statements columns on extension version

### DIFF
--- a/pkg/pg/build_catalog_collectors.go
+++ b/pkg/pg/build_catalog_collectors.go
@@ -77,7 +77,7 @@ func BuildCatalogCollectors(
 		{queries.WaitEventsCollector(pool, prepareCtx), simpleBase(queries.WaitEventsName)},
 
 		// Typed collectors
-		{queries.PgStatStatementsCollector(pool, prepareCtx, cfg.PgStatStatements.Extra, pgMajorVersion), cfg.PgStatStatements.Base},
+		{queries.PgStatStatementsCollector(pool, prepareCtx, cfg.PgStatStatements.Extra), cfg.PgStatStatements.Base},
 		{queries.PgClassCollector(pool, prepareCtx, cfg.PgClass.Extra), cfg.PgClass.Base},
 		{queries.PgStatsCollector(pool, prepareCtx, cfg.PgStats.Extra), cfg.PgStats.Base},
 		{queries.PgStatUserTablesCollector(pool, prepareCtx, cfg.PgStatUserTables.Extra), cfg.PgStatUserTables.Base},

--- a/pkg/pg/queries/collectors_integration_test.go
+++ b/pkg/pg/queries/collectors_integration_test.go
@@ -1598,7 +1598,7 @@ func TestPgStatStatements_AllVersions(t *testing.T) {
 					DiffLimit:          PgStatStatementsDiffLimit,
 					IncludeQueries:     true,
 					MaxQueryTextLength: 1000,
-				}, inst.version,
+				},
 			)
 
 			// First call: snapshot, no deltas, no avg runtime.
@@ -1677,6 +1677,142 @@ func TestPgStatStatements_AllVersions(t *testing.T) {
 	}
 }
 
+// TestPgStatStatements_AdaptsToOldExtensionOnNewServer is the integration-level
+// regression test for the bug where the collector built the query from the
+// PostgreSQL server major version instead of the pg_stat_statements extension
+// version. On a server upgraded to PG 17 with the extension still pinned at
+// 1.10 (the realistic Amazon RDS state until ALTER EXTENSION ... UPDATE is
+// run), the old logic generated SELECT shared_blk_read_time which does not
+// exist in the 1.10 view (SQLSTATE 42703). This test reproduces that exact
+// "new server / old extension" combination by explicitly creating the
+// extension at version 1.10 in a fresh database, then exercises the
+// version-change rebuild path by ALTERing the extension up to 1.11.
+//
+// The reproduction depends on the PG container shipping the
+// pg_stat_statements--*--*.sql upgrade scripts down to 1.4 (it does, see
+// contrib/pg_stat_statements in the postgres source tree). PG 15 is the
+// earliest version that supports installing at exactly 1.10; PG 17 is the
+// earliest version that supports updating to 1.11.
+func TestPgStatStatements_AdaptsToOldExtensionOnNewServer(t *testing.T) {
+	for _, inst := range pgInstances {
+		// PG 15 is the earliest version where 1.10 is reachable as the
+		// install target. On PG 13/14, the contrib package still tops out at
+		// 1.9 / 1.8 respectively, so installing at 1.10 isn't possible.
+		if inst.version < 15 {
+			continue
+		}
+		inst := inst
+		t.Run(fmt.Sprintf("PG%d_install_ext_1_10", inst.version), func(t *testing.T) {
+			// No t.Parallel() — we create and drop a fresh database, but
+			// keeping things sequential makes failure modes easier to read.
+			ctx := context.Background()
+
+			// Create an isolated database so we don't disturb shared
+			// extension state in testdb (which other parallel subtests rely
+			// on).
+			dbName := fmt.Sprintf("pgss_oldext_pg%d", inst.version)
+			if _, err := inst.admin.Exec(ctx, fmt.Sprintf("CREATE DATABASE %s", dbName)); err != nil {
+				t.Fatalf("CREATE DATABASE %s: %v", dbName, err)
+			}
+			t.Cleanup(func() {
+				// Force-disconnect any leftover sessions so DROP succeeds.
+				_, _ = inst.admin.Exec(ctx,
+					"SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1 AND pid <> pg_backend_pid()",
+					dbName)
+				_, _ = inst.admin.Exec(ctx, fmt.Sprintf("DROP DATABASE IF EXISTS %s", dbName))
+			})
+
+			// Build a pool to the fresh database (admin user, since CREATE
+			// EXTENSION needs superuser).
+			baseConn, err := inst.container.ConnectionString(ctx, "sslmode=disable")
+			if err != nil {
+				t.Fatalf("ConnectionString: %v", err)
+			}
+			cfg, err := pgxpool.ParseConfig(baseConn)
+			if err != nil {
+				t.Fatalf("pgxpool.ParseConfig: %v", err)
+			}
+			cfg.ConnConfig.Database = dbName
+			pool, err := pgxpool.NewWithConfig(ctx, cfg)
+			if err != nil {
+				t.Fatalf("pgxpool.NewWithConfig: %v", err)
+			}
+			defer pool.Close()
+
+			// Install pg_stat_statements at exactly 1.10 — the extension
+			// version that lacks shared_blk_read_time.
+			if _, err := pool.Exec(ctx, "CREATE EXTENSION pg_stat_statements VERSION '1.10'"); err != nil {
+				t.Fatalf("CREATE EXTENSION pg_stat_statements VERSION '1.10': %v", err)
+			}
+
+			// Sanity: confirm the installed version is what we asked for.
+			var installed string
+			if err := pool.QueryRow(ctx, "SELECT extversion FROM pg_extension WHERE extname='pg_stat_statements'").Scan(&installed); err != nil {
+				t.Fatalf("SELECT extversion: %v", err)
+			}
+			if installed != "1.10" {
+				t.Fatalf("expected installed extversion 1.10, got %q", installed)
+			}
+
+			// Generate some pg_stat_statements activity.
+			for i := 0; i < 5; i++ {
+				_, _ = pool.Exec(ctx, "SELECT count(*) FROM pg_class WHERE oid > $1", i*100)
+			}
+
+			c := PgStatStatementsCollector(pool, noopPrepareCtx, PgStatStatementsConfig{
+				DiffLimit:          PgStatStatementsDiffLimit,
+				IncludeQueries:     true,
+				MaxQueryTextLength: 1000,
+			})
+
+			// REGRESSION: under the old (server-version-based) gate, this
+			// Collect() would fail on PG >= 17 with
+			//   ERROR: column "shared_blk_read_time" does not exist
+			// because the server reports >=17 but the 1.10 view only has
+			// blk_read_time. The new (extension-version-based) gate must
+			// succeed.
+			r1, err := c.Collect(ctx)
+			if err != nil {
+				t.Fatalf("PG%d + ext 1.10: Collect failed (regression): %v", inst.version, err)
+			}
+			var p1 PgStatStatementsPayload
+			if err := json.Unmarshal(r1.JSON, &p1); err != nil {
+				t.Fatalf("unmarshal first payload: %v", err)
+			}
+			if len(p1.Rows) == 0 {
+				t.Fatalf("PG%d + ext 1.10: expected non-empty rows", inst.version)
+			}
+
+			// Exercise the version-change rebuild path by upgrading the
+			// extension to 1.11. This is only meaningful (and only
+			// reachable) on PG 17+, since 1.11 was added with PG 17.
+			if inst.version >= 17 {
+				if _, err := pool.Exec(ctx, "ALTER EXTENSION pg_stat_statements UPDATE TO '1.11'"); err != nil {
+					t.Fatalf("ALTER EXTENSION ... UPDATE TO '1.11': %v", err)
+				}
+
+				// Generate additional activity so the collector has fresh
+				// rows to report after the rebuild.
+				for i := 0; i < 5; i++ {
+					_, _ = pool.Exec(ctx, "SELECT count(*) FROM pg_attribute WHERE attnum > $1", i)
+				}
+
+				r2, err := c.Collect(ctx)
+				if err != nil {
+					t.Fatalf("PG%d + ext 1.11 (after UPDATE): Collect failed: %v", inst.version, err)
+				}
+				var p2 PgStatStatementsPayload
+				if err := json.Unmarshal(r2.JSON, &p2); err != nil {
+					t.Fatalf("unmarshal second payload: %v", err)
+				}
+				if len(p2.Rows) == 0 {
+					t.Fatalf("PG%d + ext 1.11: expected non-empty rows after extension UPDATE", inst.version)
+				}
+			}
+		})
+	}
+}
+
 func TestAutovacuumCount_ReturnsData(t *testing.T) {
 	forEachPG(t, func(t *testing.T, inst pgInstance) {
 		c := AutovacuumCountCollector(inst.pool, noopPrepareCtx)
@@ -1717,7 +1853,7 @@ func buildCollectors(pool *pgxpool.Pool, pgMajorVersion int) []CatalogCollector 
 			DiffLimit:          PgStatStatementsDiffLimit,
 			IncludeQueries:     true,
 			MaxQueryTextLength: 1000,
-		}, pgMajorVersion),
+		}),
 		PgStatSubscriptionCollector(pool, noopPrepareCtx),
 		PgStatSubscriptionStatsCollector(pool, noopPrepareCtx, pgMajorVersion),
 		PgStatUserFunctionsCollector(pool, noopPrepareCtx),

--- a/pkg/pg/queries/pg_stat_statements.go
+++ b/pkg/pg/queries/pg_stat_statements.go
@@ -124,8 +124,62 @@ type PgStatStatementsPayload struct {
 	AverageQueryRuntime float64                 `json:"average_query_runtime"`
 }
 
-// buildPgStatStatementsQuery returns a version-specific query for pg_stat_statements.
-func buildPgStatStatementsQuery(includeQueries bool, maxQueryTextLength int, pgVersion int) string {
+// PgStatStatementsExtVersion is a parsed pg_stat_statements extension version
+// (e.g. extversion '1.10' -> {Major:1, Minor:10}). The available column set is
+// determined by this extension version, not by the PostgreSQL server major
+// version: a server that has been upgraded (e.g. PG 16 -> 17) keeps the
+// previously-installed extension version until ALTER EXTENSION ... UPDATE is
+// run, so the two move independently. Managed services such as Amazon RDS
+// regularly upgrade the server but leave existing extensions at their old
+// version, producing the realistic "new server / old extension" combination.
+//
+// References:
+//   - https://www.postgresql.org/docs/current/pgstatstatements.html
+//   - https://www.postgresql.org/docs/current/sql-alterextension.html (ALTER EXTENSION ... UPDATE)
+type PgStatStatementsExtVersion struct {
+	Major int
+	Minor int
+}
+
+// GTE reports whether v is at least major.minor.
+func (v PgStatStatementsExtVersion) GTE(major, minor int) bool {
+	if v.Major != major {
+		return v.Major > major
+	}
+	return v.Minor >= minor
+}
+
+// buildPgStatStatementsQuery returns an extension-version-specific query for
+// pg_stat_statements. Column availability follows the extension changelog;
+// the version-to-PG mapping below is the default_version recorded in the
+// pg_stat_statements.control file for each PostgreSQL stable branch (the
+// canonical source of truth for which extension version a fresh PG ships).
+//
+//   - 1.8  (default in PG 13): split total_time / min_time / max_time /
+//     mean_time / stddev_time into _exec_ / _plan_ counterparts.
+//     https://github.com/postgres/postgres/blob/REL_13_STABLE/contrib/pg_stat_statements/pg_stat_statements.control
+//   - 1.9  (default in PG 14): adds the toplevel column.
+//     https://github.com/postgres/postgres/blob/REL_14_STABLE/contrib/pg_stat_statements/pg_stat_statements.control
+//     https://www.postgresql.org/docs/release/14.0/ (separate top/nested tracking)
+//   - 1.10 (default in PG 15 and PG 16): adds temp_blk_read_time /
+//     temp_blk_write_time and the jit_* columns (jit_functions,
+//     jit_generation_time, jit_inlining_count, jit_inlining_time,
+//     jit_optimization_count, jit_optimization_time, jit_emission_count,
+//     jit_emission_time).
+//     https://github.com/postgres/postgres/blob/REL_15_STABLE/contrib/pg_stat_statements/pg_stat_statements.control
+//     https://github.com/postgres/postgres/blob/REL_16_STABLE/contrib/pg_stat_statements/pg_stat_statements.control
+//     https://www.postgresql.org/docs/release/15.0/ (temp file I/O + JIT counters)
+//   - 1.11 (default in PG 17): renames blk_read_time / blk_write_time to
+//     shared_blk_read_time / shared_blk_write_time, and adds
+//     local_blk_read_time / local_blk_write_time.
+//     https://github.com/postgres/postgres/blob/REL_17_STABLE/contrib/pg_stat_statements/pg_stat_statements.control
+//     https://www.postgresql.org/docs/release/17.0/ (E.10.3.11.1 pg_stat_statements)
+//
+// Because PG 16 shipped 1.10 by default, an Amazon RDS instance upgraded from
+// PG 16 to PG 17 keeps the extension at 1.10 until the operator explicitly
+// runs ALTER EXTENSION pg_stat_statements UPDATE — that's the realistic
+// "new server / old extension" combination this gating must handle.
+func buildPgStatStatementsQuery(includeQueries bool, maxQueryTextLength int, extVersion PgStatStatementsExtVersion) string {
 	var cols []string
 
 	cols = append(cols, "userid", "dbid", "queryid")
@@ -150,7 +204,7 @@ func buildPgStatStatementsQuery(includeQueries bool, maxQueryTextLength int, pgV
 		"temp_blks_read", "temp_blks_written",
 	)
 
-	if pgVersion >= 17 {
+	if extVersion.GTE(1, 11) {
 		cols = append(cols, "shared_blk_read_time", "shared_blk_write_time")
 		cols = append(cols, "local_blk_read_time", "local_blk_write_time")
 	} else {
@@ -166,11 +220,11 @@ func buildPgStatStatementsQuery(includeQueries bool, maxQueryTextLength int, pgV
 		"wal_records", "wal_fpi", "wal_bytes",
 	)
 
-	if pgVersion >= 14 {
+	if extVersion.GTE(1, 9) {
 		cols = append(cols, "toplevel")
 	}
 
-	if pgVersion >= 15 {
+	if extVersion.GTE(1, 10) {
 		cols = append(cols,
 			"temp_blk_read_time", "temp_blk_write_time",
 			"jit_functions", "jit_generation_time",
@@ -304,37 +358,46 @@ func calculateAvgRuntime(prev, curr map[string]PgStatStatementsRow) float64 {
 	return totalExecTime / float64(totalCalls)
 }
 
-// pgMajorVersionRegex extracts the major version from SELECT version() output.
-var pgMajorVersionRegex = regexp.MustCompile(`PostgreSQL (\d+)`)
+// pgStatStatementsExtVersionRegex extracts the major.minor pair from a
+// pg_extension.extversion value such as "1.10".
+var pgStatStatementsExtVersionRegex = regexp.MustCompile(`^(\d+)\.(\d+)`)
 
-const pgVersionQuery = `SELECT version()`
+const pgStatStatementsExtVersionQuery = `SELECT extversion FROM pg_extension WHERE extname = 'pg_stat_statements'`
 
-func queryPGMajorVersion(pool *pgxpool.Pool, ctx context.Context) (int, error) {
-	var versionStr string
-	err := utils.QueryRowWithPrefix(pool, ctx, pgVersionQuery).Scan(&versionStr)
+func queryPgStatStatementsExtVersion(pool *pgxpool.Pool, ctx context.Context) (PgStatStatementsExtVersion, error) {
+	var s string
+	err := utils.QueryRowWithPrefix(pool, ctx, pgStatStatementsExtVersionQuery).Scan(&s)
 	if err != nil {
-		return 0, fmt.Errorf("failed to query PG version: %w", err)
+		return PgStatStatementsExtVersion{}, fmt.Errorf("failed to query pg_stat_statements extension version: %w", err)
 	}
-	matches := pgMajorVersionRegex.FindStringSubmatch(versionStr)
-	if len(matches) < 2 {
-		return 0, fmt.Errorf("could not parse PG version from %q", versionStr)
+	m := pgStatStatementsExtVersionRegex.FindStringSubmatch(s)
+	if len(m) < 3 {
+		return PgStatStatementsExtVersion{}, fmt.Errorf("could not parse pg_stat_statements extension version from %q", s)
 	}
-	return strconv.Atoi(matches[1])
+	major, err := strconv.Atoi(m[1])
+	if err != nil {
+		return PgStatStatementsExtVersion{}, fmt.Errorf("could not parse major version from %q: %w", s, err)
+	}
+	minor, err := strconv.Atoi(m[2])
+	if err != nil {
+		return PgStatStatementsExtVersion{}, fmt.Errorf("could not parse minor version from %q: %w", s, err)
+	}
+	return PgStatStatementsExtVersion{Major: major, Minor: minor}, nil
 }
 
 // PgStatStatementsCollector returns a CatalogCollector that queries
 // pg_stat_statements, computes deltas between consecutive snapshots,
-// and emits a structured payload. The query is version-aware and will
-// be rebuilt if a PG version change is detected.
+// and emits a structured payload. The query is rebuilt whenever the
+// detected pg_stat_statements extension version changes (e.g. after
+// ALTER EXTENSION pg_stat_statements UPDATE).
 func PgStatStatementsCollector(
 	pool *pgxpool.Pool,
 	prepareCtx PrepareCtx,
 	cfg PgStatStatementsConfig,
-	initialPGVersion int,
 ) CatalogCollector {
 	var prevSnapshot map[string]PgStatStatementsRow
-	currentVersion := initialPGVersion
-	query := buildPgStatStatementsQuery(cfg.IncludeQueries, cfg.MaxQueryTextLength, currentVersion)
+	var currentExtVersion PgStatStatementsExtVersion
+	var query string
 	scanner := pgxutil.NewScanner[PgStatStatementsRow]()
 
 	return CatalogCollector{
@@ -347,13 +410,13 @@ func PgStatStatementsCollector(
 			}
 
 			collectedAt := time.Now().UTC()
-			detectedVersion, err := queryPGMajorVersion(pool, ctx)
+			detectedExtVersion, err := queryPgStatStatementsExtVersion(pool, ctx)
 			if err != nil {
 				return nil, err
 			}
-			if detectedVersion != currentVersion {
-				currentVersion = detectedVersion
-				query = buildPgStatStatementsQuery(cfg.IncludeQueries, cfg.MaxQueryTextLength, currentVersion)
+			if detectedExtVersion != currentExtVersion {
+				currentExtVersion = detectedExtVersion
+				query = buildPgStatStatementsQuery(cfg.IncludeQueries, cfg.MaxQueryTextLength, currentExtVersion)
 				prevSnapshot = nil
 			}
 

--- a/pkg/pg/queries/pg_stat_statements_test.go
+++ b/pkg/pg/queries/pg_stat_statements_test.go
@@ -1,0 +1,155 @@
+package queries
+
+import (
+	"strings"
+	"testing"
+)
+
+// Tests for buildPgStatStatementsQuery cover the per-extension-version column
+// gating documented above the function. The historical bug was that the
+// agent gated on the PostgreSQL server major version (>=17 -> use
+// shared_blk_read_time), but the column rename happened in the extension
+// (1.10 -> 1.11). On a server that has been upgraded to PG 17 with the
+// extension still pinned at 1.10 (the realistic Amazon RDS default until
+// the operator runs ALTER EXTENSION ... UPDATE), the old gate produced a
+// query referencing shared_blk_read_time which does not exist in the 1.10
+// view, so the collector failed with SQLSTATE 42703. The case for ext=1.10
+// below is the precise regression test for that scenario.
+func TestBuildPgStatStatementsQuery_ColumnGating(t *testing.T) {
+	type expect struct {
+		mustContain    []string
+		mustNotContain []string
+	}
+	cases := []struct {
+		name string
+		v    PgStatStatementsExtVersion
+		expect
+	}{
+		{
+			name: "ext_1_8_pg13_no_toplevel_no_jit_no_temp_blk_time_blk_read_time_aliased",
+			v:    PgStatStatementsExtVersion{Major: 1, Minor: 8},
+			expect: expect{
+				mustContain: []string{
+					"blk_read_time AS shared_blk_read_time",
+					"blk_write_time AS shared_blk_write_time",
+				},
+				mustNotContain: []string{
+					"toplevel",
+					"jit_functions",
+					"temp_blk_read_time",
+					", shared_blk_read_time",
+					"local_blk_read_time",
+				},
+			},
+		},
+		{
+			name: "ext_1_9_pg14_adds_toplevel",
+			v:    PgStatStatementsExtVersion{Major: 1, Minor: 9},
+			expect: expect{
+				mustContain: []string{
+					"blk_read_time AS shared_blk_read_time",
+					"toplevel",
+				},
+				mustNotContain: []string{
+					"jit_functions",
+					"temp_blk_read_time",
+					"local_blk_read_time",
+				},
+			},
+		},
+		{
+			name: "ext_1_10_pg15_adds_temp_blk_time_and_jit",
+			v:    PgStatStatementsExtVersion{Major: 1, Minor: 10},
+			expect: expect{
+				mustContain: []string{
+					"blk_read_time AS shared_blk_read_time",
+					"toplevel",
+					"temp_blk_read_time",
+					"temp_blk_write_time",
+					"jit_functions",
+					"jit_emission_time",
+				},
+				mustNotContain: []string{
+					", shared_blk_read_time",
+					"local_blk_read_time",
+				},
+			},
+		},
+		{
+			name: "ext_1_10_on_pg17_server_regression_for_RDS_upgrade_path",
+			v:    PgStatStatementsExtVersion{Major: 1, Minor: 10},
+			expect: expect{
+				// This is the realistic Amazon RDS state after a PG 16 -> 17
+				// server upgrade without ALTER EXTENSION ... UPDATE: the
+				// query MUST still reference blk_read_time (aliased), not
+				// shared_blk_read_time, because the 1.10 view doesn't have
+				// the new column.
+				mustContain: []string{
+					"blk_read_time AS shared_blk_read_time",
+				},
+				mustNotContain: []string{
+					", shared_blk_read_time",
+					"local_blk_read_time",
+				},
+			},
+		},
+		{
+			name: "ext_1_11_pg17_renames_to_shared_blk_time_adds_local_blk_time",
+			v:    PgStatStatementsExtVersion{Major: 1, Minor: 11},
+			expect: expect{
+				mustContain: []string{
+					"shared_blk_read_time",
+					"shared_blk_write_time",
+					"local_blk_read_time",
+					"local_blk_write_time",
+					"toplevel",
+					"temp_blk_read_time",
+					"jit_functions",
+				},
+				mustNotContain: []string{
+					"blk_read_time AS shared_blk_read_time",
+					"blk_write_time AS shared_blk_write_time",
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			q := buildPgStatStatementsQuery(true, 4096, tc.v)
+			for _, s := range tc.mustContain {
+				if !strings.Contains(q, s) {
+					t.Errorf("expected query to contain %q\nquery:\n%s", s, q)
+				}
+			}
+			for _, s := range tc.mustNotContain {
+				if strings.Contains(q, s) {
+					t.Errorf("expected query NOT to contain %q\nquery:\n%s", s, q)
+				}
+			}
+		})
+	}
+}
+
+func TestPgStatStatementsExtVersion_GTE(t *testing.T) {
+	cases := []struct {
+		v          PgStatStatementsExtVersion
+		major      int
+		minor      int
+		wantResult bool
+	}{
+		{PgStatStatementsExtVersion{1, 10}, 1, 10, true},
+		{PgStatStatementsExtVersion{1, 10}, 1, 11, false},
+		{PgStatStatementsExtVersion{1, 11}, 1, 11, true},
+		{PgStatStatementsExtVersion{1, 11}, 1, 10, true},
+		{PgStatStatementsExtVersion{2, 0}, 1, 99, true},
+		{PgStatStatementsExtVersion{0, 99}, 1, 0, false},
+	}
+	for _, c := range cases {
+		got := c.v.GTE(c.major, c.minor)
+		if got != c.wantResult {
+			t.Errorf("(%d.%d).GTE(%d,%d) = %v, want %v",
+				c.v.Major, c.v.Minor, c.major, c.minor, got, c.wantResult)
+		}
+	}
+}


### PR DESCRIPTION
The collector previously decided which columns to SELECT based on the PostgreSQL server major version (>=17 -> shared_blk_read_time, etc.). The column rename actually happened in the pg_stat_statements extension (1.10 -> 1.11), and the extension and server versions move independently: an Amazon RDS instance upgraded from PG 16 to PG 17 keeps the extension at 1.10 until ALTER EXTENSION ... UPDATE is run, producing a server >=17 with a 1.10 view. Under the old gate this generated SELECT shared_blk_read_time which does not exist in the 1.10 view, failing every collect with SQLSTATE 42703.

Switch the gate to read pg_extension.extversion for pg_stat_statements and rebuild the query when it changes (covering ALTER EXTENSION UPDATE at runtime). Cutoffs are documented inline against the default_version recorded in each PostgreSQL stable branch's pg_stat_statements.control.

Add a unit test for buildPgStatStatementsQuery covering the four extension-version cutoffs (1.8, 1.9, 1.10, 1.11) including the exact "PG 17 server with extension still at 1.10" combination that the old code produced a broken query for.

Add an integration test that creates the extension at version 1.10 in a fresh database (reachable on PG >=15), runs Collect successfully, then ALTERs the extension to 1.11 on PG >=17 and Collects again to exercise the version-change rebuild path that the previous single-version-detected-once cache would have masked.