### PR TITLE
fix: limit total rows of pgss, not just deltas

### DIFF
--- a/pkg/pg/queries/pg_stat_statements.go
+++ b/pkg/pg/queries/pg_stat_statements.go
@@ -285,43 +285,72 @@ func zeroPtr[T ~int64 | ~float64](val *T, exists bool) *T {
 	return val
 }
 
-func calculateStatementDeltas(prev, curr map[string]PgStatStatementsRow, diffLimit int) ([]PgStatStatementsDelta, int) {
-	diffs := make([]PgStatStatementsDelta, 0, len(curr))
-	totalDiffs := 0
+// selectTopByRecentActivity ranks curr rows by the avg exec time of their
+// delta vs prev (the same metric the standalone delta sort used) and keeps
+// the top `limit`. For each kept row, emits a paired delta when it has a
+// positive (calls, total_exec_time) diff. `totalDiffs` is the pre-cap count
+// of rows with a positive diff — preserved as `delta_count` for the server.
+//
+// Rows with no positive diff (new rows, idle rows, first tick) sort to the
+// end with key 0 and fill any remaining slots in stable input order.
+func selectTopByRecentActivity(
+	curr []PgStatStatementsRow,
+	prev map[string]PgStatStatementsRow,
+	limit int,
+) (rows []PgStatStatementsRow, deltas []PgStatStatementsDelta, totalDiffs int) {
+	type ranked struct {
+		row     PgStatStatementsRow
+		delta   *PgStatStatementsDelta
+		sortKey float64
+		idx     int
+	}
 
-	for key, currRow := range curr {
-		prevRow, exists := prev[key]
+	all := make([]ranked, 0, len(curr))
+	for i, currRow := range curr {
+		entry := ranked{row: currRow, idx: i}
 
-		callsDiff := ptrDiff(zeroPtr(prevRow.Calls, exists), currRow.Calls)
-		execTimeDiff := ptrDiff(zeroPtr(prevRow.TotalExecTime, exists), currRow.TotalExecTime)
+		if prev != nil {
+			prevRow, exists := prev[compositeKey(&currRow)]
+			callsDiff := ptrDiff(zeroPtr(prevRow.Calls, exists), currRow.Calls)
+			execDiff := ptrDiff(zeroPtr(prevRow.TotalExecTime, exists), currRow.TotalExecTime)
 
-		if callsDiff == nil || *callsDiff <= 0 ||
-			execTimeDiff == nil || *execTimeDiff <= 0 {
-			continue
+			if callsDiff != nil && *callsDiff > 0 &&
+				execDiff != nil && *execDiff > 0 {
+				totalDiffs++
+				entry.delta = &PgStatStatementsDelta{
+					UserID:        currRow.UserID,
+					DbID:          currRow.DbID,
+					QueryID:       currRow.QueryID,
+					Calls:         callsDiff,
+					TotalExecTime: execDiff,
+				}
+				entry.sortKey = float64(*execDiff) / float64(*callsDiff)
+			}
 		}
 
-		totalDiffs++
-
-		diffs = append(diffs, PgStatStatementsDelta{
-			UserID:        currRow.UserID,
-			DbID:          currRow.DbID,
-			QueryID:       currRow.QueryID,
-			Calls:         callsDiff,
-			TotalExecTime: execTimeDiff,
-		})
+		all = append(all, entry)
 	}
 
-	sort.Slice(diffs, func(i, j int) bool {
-		avgI := float64(*diffs[i].TotalExecTime) / float64(*diffs[i].Calls)
-		avgJ := float64(*diffs[j].TotalExecTime) / float64(*diffs[j].Calls)
-		return avgI > avgJ
+	sort.SliceStable(all, func(i, j int) bool {
+		if all[i].sortKey != all[j].sortKey {
+			return all[i].sortKey > all[j].sortKey
+		}
+		return all[i].idx < all[j].idx
 	})
 
-	if len(diffs) > diffLimit {
-		diffs = diffs[:diffLimit]
+	if limit > 0 && len(all) > limit {
+		all = all[:limit]
 	}
 
-	return diffs, totalDiffs
+	rows = make([]PgStatStatementsRow, 0, len(all))
+	deltas = make([]PgStatStatementsDelta, 0, len(all))
+	for _, entry := range all {
+		rows = append(rows, entry.row)
+		if entry.delta != nil {
+			deltas = append(deltas, *entry.delta)
+		}
+	}
+	return rows, deltas, totalDiffs
 }
 
 func calculateAvgRuntime(prev, curr map[string]PgStatStatementsRow) float64 {
@@ -430,17 +459,23 @@ func PgStatStatementsCollector(
 
 			currSnapshot := toSnapshot(rows)
 
+			// Rank curr rows by recent activity (avg exec time of the
+			// delta vs prev) and cap to DiffLimit. Deltas are emitted only
+			// for kept rows. The full snapshot is retained as prevSnapshot
+			// so the next tick's delta math sees every row.
+			outRows, outDeltas, totalDiffs := selectTopByRecentActivity(
+				rows, prevSnapshot, cfg.DiffLimit,
+			)
+
 			payload := &PgStatStatementsPayload{
 				CollectedAt: collectedAt,
-				Rows:        rows,
+				Rows:        outRows,
 			}
 
 			if prevSnapshot != nil {
-				deltas, deltaCount := calculateStatementDeltas(prevSnapshot, currSnapshot, cfg.DiffLimit)
-				avgRuntime := calculateAvgRuntime(prevSnapshot, currSnapshot)
-				payload.Deltas = deltas
-				payload.DeltaCount = deltaCount
-				payload.AverageQueryRuntime = avgRuntime
+				payload.Deltas = outDeltas
+				payload.DeltaCount = totalDiffs
+				payload.AverageQueryRuntime = calculateAvgRuntime(prevSnapshot, currSnapshot)
 			}
 
 			prevSnapshot = currSnapshot

--- a/pkg/pg/queries/pg_stat_statements.go
+++ b/pkg/pg/queries/pg_stat_statements.go
@@ -252,17 +252,6 @@ func compositeKey(r *PgStatStatementsRow) string {
 	return fmt.Sprintf("%d_%d_%d", qid, uid, did)
 }
 
-func toSnapshot(rows []PgStatStatementsRow) map[string]PgStatStatementsRow {
-	m := make(map[string]PgStatStatementsRow, len(rows))
-	for _, r := range rows {
-		if r.QueryID == nil || r.UserID == nil || r.DbID == nil {
-			continue
-		}
-		m[compositeKey(&r)] = r
-	}
-	return m
-}
-
 // ptrDiff returns *curr - *prev if both are non-nil and the result is non-negative.
 func ptrDiff[T ~int64 | ~float64](prev, curr *T) *T {
 	if prev == nil || curr == nil {
@@ -285,38 +274,66 @@ func zeroPtr[T ~int64 | ~float64](val *T, exists bool) *T {
 	return val
 }
 
-// selectTopByRecentActivity ranks curr rows by the avg exec time of their
-// delta vs prev (the same metric the standalone delta sort used) and keeps
-// the top `limit`. For each kept row, emits a paired delta when it has a
-// positive (calls, total_exec_time) diff. `totalDiffs` is the pre-cap count
-// of rows with a positive diff — preserved as `delta_count` for the server.
+// buildPayloadParts walks the curr rows once and produces everything the
+// payload needs:
+//
+//   - rows / deltas: top `limit` curr rows, ranked by the delta's avg exec
+//     time (same metric the standalone delta sort previously used); each
+//     kept row gets a paired delta when it had a positive
+//     (calls, total_exec_time) diff vs prev.
+//   - totalDiffs: pre-cap count of rows with a positive diff (the
+//     `delta_count` reported to the server).
+//   - avgRuntime: total_exec_time / total_calls summed across ALL
+//     positive-diff rows in the snapshot — independent of the row/delta
+//     cap, so the AQR reflects the whole database, not just kept rows.
 //
 // Rows with no positive diff (new rows, idle rows, first tick) sort to the
 // end with key 0 and fill any remaining slots in stable input order.
-func selectTopByRecentActivity(
+func buildPayloadParts(
 	curr []PgStatStatementsRow,
 	prev map[string]PgStatStatementsRow,
 	limit int,
-) (rows []PgStatStatementsRow, deltas []PgStatStatementsDelta, totalDiffs int) {
+) (
+	rows []PgStatStatementsRow,
+	deltas []PgStatStatementsDelta,
+	totalDiffs int,
+	avgRuntime float64,
+	nextSnapshot map[string]PgStatStatementsRow,
+) {
 	type ranked struct {
 		row     PgStatStatementsRow
 		delta   *PgStatStatementsDelta
 		sortKey float64
-		idx     int
 	}
 
 	all := make([]ranked, 0, len(curr))
-	for i, currRow := range curr {
-		entry := ranked{row: currRow, idx: i}
+	nextSnapshot = make(map[string]PgStatStatementsRow, len(curr))
+	var totalCalls int64
+	var totalExecTime float64
 
-		if prev != nil {
-			prevRow, exists := prev[compositeKey(&currRow)]
+	for _, currRow := range curr {
+		entry := ranked{row: currRow}
+
+		// Build the next-tick snapshot inline. Skip rows missing any of
+		// the composite-key components — they'd collide on "0_0_0" and
+		// can't match anything on the next tick anyway.
+		hasKey := currRow.QueryID != nil && currRow.UserID != nil && currRow.DbID != nil
+		var key string
+		if hasKey {
+			key = compositeKey(&currRow)
+			nextSnapshot[key] = currRow
+		}
+
+		if prev != nil && hasKey {
+			prevRow, exists := prev[key]
 			callsDiff := ptrDiff(zeroPtr(prevRow.Calls, exists), currRow.Calls)
 			execDiff := ptrDiff(zeroPtr(prevRow.TotalExecTime, exists), currRow.TotalExecTime)
 
 			if callsDiff != nil && *callsDiff > 0 &&
 				execDiff != nil && *execDiff > 0 {
 				totalDiffs++
+				totalCalls += int64(*callsDiff)
+				totalExecTime += float64(*execDiff)
 				entry.delta = &PgStatStatementsDelta{
 					UserID:        currRow.UserID,
 					DbID:          currRow.DbID,
@@ -331,11 +348,14 @@ func selectTopByRecentActivity(
 		all = append(all, entry)
 	}
 
+	if totalCalls > 0 {
+		avgRuntime = totalExecTime / float64(totalCalls)
+	} else {
+		avgRuntime = 0.0
+	}
+
 	sort.SliceStable(all, func(i, j int) bool {
-		if all[i].sortKey != all[j].sortKey {
-			return all[i].sortKey > all[j].sortKey
-		}
-		return all[i].idx < all[j].idx
+		return all[i].sortKey > all[j].sortKey
 	})
 
 	if limit > 0 && len(all) > limit {
@@ -350,41 +370,7 @@ func selectTopByRecentActivity(
 			deltas = append(deltas, *entry.delta)
 		}
 	}
-	return rows, deltas, totalDiffs
-}
-
-func calculateAvgRuntime(prev, curr map[string]PgStatStatementsRow) float64 {
-	totalExecTime := 0.0
-	totalCalls := int64(0)
-
-	for key, currRow := range curr {
-		if currRow.Calls == nil || currRow.TotalExecTime == nil {
-			continue
-		}
-
-		prevRow, exists := prev[key]
-		var prevCalls int64
-		var prevExecTime float64
-		if exists && prevRow.Calls != nil {
-			prevCalls = int64(*prevRow.Calls)
-		}
-		if exists && prevRow.TotalExecTime != nil {
-			prevExecTime = float64(*prevRow.TotalExecTime)
-		}
-
-		callsDiff := int64(*currRow.Calls) - prevCalls
-		execTimeDiff := float64(*currRow.TotalExecTime) - prevExecTime
-
-		if callsDiff > 0 && execTimeDiff > 0 {
-			totalCalls += callsDiff
-			totalExecTime += execTimeDiff
-		}
-	}
-
-	if totalCalls == 0 {
-		return 0.0
-	}
-	return totalExecTime / float64(totalCalls)
+	return rows, deltas, totalDiffs, avgRuntime, nextSnapshot
 }
 
 // pgStatStatementsExtVersionRegex extracts the major.minor pair from a
@@ -457,13 +443,11 @@ func PgStatStatementsCollector(
 				return nil, err
 			}
 
-			currSnapshot := toSnapshot(rows)
-
-			// Rank curr rows by recent activity (avg exec time of the
-			// delta vs prev) and cap to DiffLimit. Deltas are emitted only
-			// for kept rows. The full snapshot is retained as prevSnapshot
-			// so the next tick's delta math sees every row.
-			outRows, outDeltas, totalDiffs := selectTopByRecentActivity(
+			// Single pass over curr rows: produces capped rows/deltas
+			// (ranked by delta avg exec time), the overall AQR computed
+			// across the FULL snapshot, and the curr snapshot map reused
+			// as prevSnapshot on the next tick.
+			outRows, outDeltas, totalDiffs, avgRuntime, currSnapshot := buildPayloadParts(
 				rows, prevSnapshot, cfg.DiffLimit,
 			)
 
@@ -475,7 +459,7 @@ func PgStatStatementsCollector(
 			if prevSnapshot != nil {
 				payload.Deltas = outDeltas
 				payload.DeltaCount = totalDiffs
-				payload.AverageQueryRuntime = calculateAvgRuntime(prevSnapshot, currSnapshot)
+				payload.AverageQueryRuntime = avgRuntime
 			}
 
 			prevSnapshot = currSnapshot

--- a/pkg/pg/queries/pg_stat_statements_test.go
+++ b/pkg/pg/queries/pg_stat_statements_test.go
@@ -8,7 +8,7 @@ import (
 func ptrOf[T any](v T) *T { return &v }
 
 // mkRow builds a minimal PgStatStatementsRow with the fields needed by
-// selectTopByRecentActivity / calculateAvgRuntime: queryid/userid/dbid for
+// buildPayloadParts / calculateAvgRuntime: queryid/userid/dbid for
 // composite-key matching, and calls/total_exec_time for the delta math.
 func mkRow(queryID int64, calls int64, totalExecTime float64) PgStatStatementsRow {
 	return PgStatStatementsRow{
@@ -21,11 +21,15 @@ func mkRow(queryID int64, calls int64, totalExecTime float64) PgStatStatementsRo
 }
 
 func snapshotOf(rows []PgStatStatementsRow) map[string]PgStatStatementsRow {
-	return toSnapshot(rows)
+	m := make(map[string]PgStatStatementsRow, len(rows))
+	for _, r := range rows {
+		m[compositeKey(&r)] = r
+	}
+	return m
 }
 
 // Three behaviours covered:
-//   1. selectTopByRecentActivity caps rows AND deltas to the same limit.
+//   1. buildPayloadParts caps rows AND deltas to the same limit.
 //   2. Every emitted delta has a matching row in the emitted rows slice
 //      (i.e. rows is a strict superset, by composite key, of deltas).
 //   3. The avg-query-runtime reported by the payload is computed over the
@@ -49,7 +53,7 @@ func TestSelectTopByRecentActivity_CapsRowsAndDeltas(t *testing.T) {
 	}
 
 	const limit = 2
-	rows, deltas, totalDiffs := selectTopByRecentActivity(curr, prev, limit)
+	rows, deltas, totalDiffs, _, _ := buildPayloadParts(curr, prev, limit)
 
 	if len(rows) != limit {
 		t.Fatalf("len(rows) = %d, want %d", len(rows), limit)
@@ -84,7 +88,7 @@ func TestSelectTopByRecentActivity_EveryDeltaHasMatchingRow(t *testing.T) {
 		mkRow(5, 10, 100.0), // no diff
 	}
 
-	rows, deltas, _ := selectTopByRecentActivity(curr, prev, 3)
+	rows, deltas, _, _, _ := buildPayloadParts(curr, prev, 3)
 
 	rowIDs := map[int64]struct{}{}
 	for _, r := range rows {
@@ -98,10 +102,8 @@ func TestSelectTopByRecentActivity_EveryDeltaHasMatchingRow(t *testing.T) {
 	}
 }
 
-// The collector computes AverageQueryRuntime via calculateAvgRuntime over
-// the full prev/curr snapshots — not over the post-cap selection — so the
-// reported AQR reflects every query the database executed, even when the
-// rows/deltas payload is trimmed.
+// The AQR returned by buildPayloadParts must reflect every positive-diff
+// query in the snapshot, not just the queries kept after the row/delta cap.
 func TestAverageQueryRuntime_IncludesAllQueriesNotJustCapped(t *testing.T) {
 	prev := snapshotOf([]PgStatStatementsRow{
 		mkRow(1, 0, 0.0),
@@ -109,25 +111,22 @@ func TestAverageQueryRuntime_IncludesAllQueriesNotJustCapped(t *testing.T) {
 		mkRow(3, 0, 0.0),
 	})
 	// Total across ALL three queries: 30 calls, 600 ms  =>  AQR = 20.0
-	currRows := []PgStatStatementsRow{
+	curr := []PgStatStatementsRow{
 		mkRow(1, 10, 100.0),
 		mkRow(2, 10, 200.0),
 		mkRow(3, 10, 300.0),
 	}
-	currSnapshot := snapshotOf(currRows)
 
 	// Cap aggressively — only 1 query survives the row/delta cap.
-	rows, _, _ := selectTopByRecentActivity(currRows, prev, 1)
+	rows, _, _, avgRuntime, _ := buildPayloadParts(curr, prev, 1)
 	if len(rows) != 1 {
 		t.Fatalf("precondition: expected cap to leave 1 row, got %d", len(rows))
 	}
 
-	// AQR still uses the full snapshot, independent of the cap.
-	got := calculateAvgRuntime(prev, currSnapshot)
 	const want = 20.0
-	if got != want {
-		t.Fatalf("AverageQueryRuntime = %f, want %f (AQR must use full snapshot, not capped rows)",
-			got, want)
+	if avgRuntime != want {
+		t.Fatalf("avgRuntime = %f, want %f (AQR must use full snapshot, not capped rows)",
+			avgRuntime, want)
 	}
 }
 

--- a/pkg/pg/queries/pg_stat_statements_test.go
+++ b/pkg/pg/queries/pg_stat_statements_test.go
@@ -5,6 +5,132 @@ import (
 	"testing"
 )
 
+func ptrOf[T any](v T) *T { return &v }
+
+// mkRow builds a minimal PgStatStatementsRow with the fields needed by
+// selectTopByRecentActivity / calculateAvgRuntime: queryid/userid/dbid for
+// composite-key matching, and calls/total_exec_time for the delta math.
+func mkRow(queryID int64, calls int64, totalExecTime float64) PgStatStatementsRow {
+	return PgStatStatementsRow{
+		QueryID:       ptrOf(Bigint(queryID)),
+		UserID:        ptrOf(Oid(1)),
+		DbID:          ptrOf(Oid(1)),
+		Calls:         ptrOf(Bigint(calls)),
+		TotalExecTime: ptrOf(DoublePrecision(totalExecTime)),
+	}
+}
+
+func snapshotOf(rows []PgStatStatementsRow) map[string]PgStatStatementsRow {
+	return toSnapshot(rows)
+}
+
+// Three behaviours covered:
+//   1. selectTopByRecentActivity caps rows AND deltas to the same limit.
+//   2. Every emitted delta has a matching row in the emitted rows slice
+//      (i.e. rows is a strict superset, by composite key, of deltas).
+//   3. The avg-query-runtime reported by the payload is computed over the
+//      FULL snapshot — every query the agent saw — not just the queries
+//      that made it past the cap.
+
+func TestSelectTopByRecentActivity_CapsRowsAndDeltas(t *testing.T) {
+	prev := snapshotOf([]PgStatStatementsRow{
+		mkRow(1, 10, 100.0),
+		mkRow(2, 10, 100.0),
+		mkRow(3, 10, 100.0),
+		mkRow(4, 10, 100.0),
+		mkRow(5, 10, 100.0),
+	})
+	curr := []PgStatStatementsRow{
+		mkRow(1, 20, 110.0),  // delta avg   1
+		mkRow(2, 20, 300.0),  // delta avg  20
+		mkRow(3, 20, 200.0),  // delta avg  10
+		mkRow(4, 20, 1100.0), // delta avg 100   <- top
+		mkRow(5, 20, 600.0),  // delta avg  50   <- 2nd
+	}
+
+	const limit = 2
+	rows, deltas, totalDiffs := selectTopByRecentActivity(curr, prev, limit)
+
+	if len(rows) != limit {
+		t.Fatalf("len(rows) = %d, want %d", len(rows), limit)
+	}
+	if len(deltas) != limit {
+		t.Fatalf("len(deltas) = %d, want %d", len(deltas), limit)
+	}
+	if totalDiffs != 5 {
+		t.Fatalf("totalDiffs = %d, want 5 (pre-cap count of positive diffs)", totalDiffs)
+	}
+	// Highest-avg-exec-time deltas survive the cap.
+	if int64(*rows[0].QueryID) != 4 || int64(*rows[1].QueryID) != 5 {
+		t.Fatalf("expected top-2 rows = [4, 5], got [%d, %d]",
+			*rows[0].QueryID, *rows[1].QueryID)
+	}
+}
+
+func TestSelectTopByRecentActivity_EveryDeltaHasMatchingRow(t *testing.T) {
+	// Mix of positive-diff rows and unchanged rows; cap below total.
+	prev := snapshotOf([]PgStatStatementsRow{
+		mkRow(1, 10, 100.0),
+		mkRow(2, 10, 100.0),
+		mkRow(3, 10, 100.0),
+		mkRow(4, 10, 100.0),
+		mkRow(5, 10, 100.0),
+	})
+	curr := []PgStatStatementsRow{
+		mkRow(1, 20, 300.0), // delta
+		mkRow(2, 20, 200.0), // delta
+		mkRow(3, 20, 110.0), // delta
+		mkRow(4, 10, 100.0), // no diff
+		mkRow(5, 10, 100.0), // no diff
+	}
+
+	rows, deltas, _ := selectTopByRecentActivity(curr, prev, 3)
+
+	rowIDs := map[int64]struct{}{}
+	for _, r := range rows {
+		rowIDs[int64(*r.QueryID)] = struct{}{}
+	}
+	for i, d := range deltas {
+		if _, ok := rowIDs[int64(*d.QueryID)]; !ok {
+			t.Fatalf("deltas[%d] queryid=%d has no matching row in rows (rowIDs=%v)",
+				i, *d.QueryID, rowIDs)
+		}
+	}
+}
+
+// The collector computes AverageQueryRuntime via calculateAvgRuntime over
+// the full prev/curr snapshots — not over the post-cap selection — so the
+// reported AQR reflects every query the database executed, even when the
+// rows/deltas payload is trimmed.
+func TestAverageQueryRuntime_IncludesAllQueriesNotJustCapped(t *testing.T) {
+	prev := snapshotOf([]PgStatStatementsRow{
+		mkRow(1, 0, 0.0),
+		mkRow(2, 0, 0.0),
+		mkRow(3, 0, 0.0),
+	})
+	// Total across ALL three queries: 30 calls, 600 ms  =>  AQR = 20.0
+	currRows := []PgStatStatementsRow{
+		mkRow(1, 10, 100.0),
+		mkRow(2, 10, 200.0),
+		mkRow(3, 10, 300.0),
+	}
+	currSnapshot := snapshotOf(currRows)
+
+	// Cap aggressively — only 1 query survives the row/delta cap.
+	rows, _, _ := selectTopByRecentActivity(currRows, prev, 1)
+	if len(rows) != 1 {
+		t.Fatalf("precondition: expected cap to leave 1 row, got %d", len(rows))
+	}
+
+	// AQR still uses the full snapshot, independent of the cap.
+	got := calculateAvgRuntime(prev, currSnapshot)
+	const want = 20.0
+	if got != want {
+		t.Fatalf("AverageQueryRuntime = %f, want %f (AQR must use full snapshot, not capped rows)",
+			got, want)
+	}
+}
+
 // Tests for buildPgStatStatementsQuery cover the per-extension-version column
 // gating documented above the function. The historical bug was that the
 // agent gated on the PostgreSQL server major version (>=17 -> use


### PR DESCRIPTION
During the push for agent 1.1+, we did not add a limit to the cumulative data we sent back, meaning the top-500 PGSS limit only applied to the deltas, and not the cumulatives, which is capped at `pgss_statements.max`. This caused unnecessarily large payloads on heavily active databases.