### PR TITLE
feat: restarts in `pgprem` via specifying a script path

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ export DBT_DBTUNE_SERVER_URL="https://app.dbtune.com"
 export DBT_DBTUNE_API_KEY=""
 export DBT_DBTUNE_DATABASE_ID=""
 export DBT_POSTGRESQL_ALLOW_RESTART=false  # Set to true to allow PostgreSQL restarts
+export DBT_POSTGRESQL_RESTART_SCRIPT_PATH=""  # Optional. Path to a custom restart script (see below).
 
 # Your database specific
 export DBT_POSTGRESQL_CONNECTION_URL=postgresql://user:password@localhost:5432/database
@@ -177,6 +178,33 @@ sudo systemctl enable --now dbtune-agent
 ```
 
 Once started you can check and verify that the dbtune-agent is running by looking at the journal, for example: `journalctl -u dbtune-agent -f`
+
+### Using a custom restart script
+
+If restarting the database can't be done through `systemctl` (e.g. you need `pg_ctl`, a
+container exec, or a privileged wrapper), you can point the agent at your own restart script.
+
+To do so, export the path to an executable script:
+```bash
+export DBT_POSTGRESQL_RESTART_SCRIPT_PATH=/path/to/your/restart.sh
+```
+When set, this takes precedence over `DBT_POSTGRESQL_SERVICE_NAME` and the agent executes the
+script directly (no shell — the value must be a bare executable path with no arguments). The
+file must exist and be executable (`chmod +x`); the agent validates this on startup.
+
+The script must signal success with exit code `0` and failure with any non-zero exit code.
+Output on stdout/stderr is logged on failure but does not by itself indicate failure — many
+tools (including `pg_ctl`) write to stderr during normal operation.
+
+An example of such a restart script using `pg_ctl` instead of `systemctl`:
+```sh
+#!/bin/bash
+set -eo pipefail
+
+# Restarts the database using pg_ctl, and a timeout of 10min.
+# Assumes PGDATA points to the data folder of postgres.
+exec gosu postgres pg_ctl restart -D "$PGDATA" -m fast -w -t 600
+```
 
 ### AWS Fargate / ECS
 Follow these [README](fargate/README.md) instructions to run the agent under AWS Fargate as a service.

--- a/pkg/pg/config.go
+++ b/pkg/pg/config.go
@@ -14,9 +14,10 @@ const (
 )
 
 type Config struct {
-	ConnectionURL string `mapstructure:"connection_url" validate:"required"`
-	ServiceName   string `mapstructure:"service_name"` // TODO(eddie): Should be moved under pgprem, as it doesn't apply to all other PG providers
-	AllowRestart  bool   `mapstructure:"allow_restart"`
+	ConnectionURL     string `mapstructure:"connection_url" validate:"required"`
+	ServiceName       string `mapstructure:"service_name"`        // TODO(eddie): Should be moved under pgprem, as it doesn't apply to all other PG providers
+	RestartScriptPath string `mapstructure:"restart_script_path"` // When set, restarts execute this script directly (no shell) instead of `systemctl restart`. Must be an executable path with no arguments. Takes precedence over ServiceName.
+	AllowRestart      bool   `mapstructure:"allow_restart"`
 }
 
 func ConfigFromViper(key *string) (Config, error) {
@@ -42,6 +43,7 @@ func ConfigFromViper(key *string) (Config, error) {
 
 	_ = dbtuneConfig.BindEnv("connection_url", "DBT_POSTGRESQL_CONNECTION_URL")
 	_ = dbtuneConfig.BindEnv("service_name", "DBT_POSTGRESQL_SERVICE_NAME")
+	_ = dbtuneConfig.BindEnv("restart_script_path", "DBT_POSTGRESQL_RESTART_SCRIPT_PATH")
 	_ = dbtuneConfig.BindEnv("allow_restart", "DBT_POSTGRESQL_ALLOW_RESTART")
 
 	// Also bind on the global viper so dotted lookups like
@@ -49,7 +51,7 @@ func ConfigFromViper(key *string) (Config, error) {
 	// resolve the env var. BindEnv on a sub-viper does not propagate to the parent.
 	_ = viper.BindEnv("postgresql.connection_url", "DBT_POSTGRESQL_CONNECTION_URL")
 	_ = viper.BindEnv("postgresql.service_name", "DBT_POSTGRESQL_SERVICE_NAME")
-	_ = viper.BindEnv("postgresql.use_restart_command", "DBT_POSTGRESQL_USE_RESTART_COMMAND")
+	_ = viper.BindEnv("postgresql.restart_script_path", "DBT_POSTGRESQL_RESTART_SCRIPT_PATH")
 	_ = viper.BindEnv("postgresql.allow_restart", "DBT_POSTGRESQL_ALLOW_RESTART")
 
 	dbtuneConfig.SetDefault("allow_restart", false)
@@ -67,8 +69,8 @@ func ConfigFromViper(key *string) (Config, error) {
 		return Config{}, err
 	}
 
-	if pgConfig.AllowRestart && runtime.GOOS == "windows" {
-		return Config{}, fmt.Errorf("postgresql.allow_restart is not supported on Windows: the agent restarts PostgreSQL via systemctl, which has no Windows equivalent yet. Set postgresql.allow_restart=false (or unset DBT_POSTGRESQL_ALLOW_RESTART) to run the agent in monitoring/reload-only mode")
+	if pgConfig.AllowRestart && pgConfig.RestartScriptPath == "" && runtime.GOOS == "windows" {
+		return Config{}, fmt.Errorf("postgresql.allow_restart is not supported on Windows: the agent restarts PostgreSQL via systemctl, which has no Windows equivalent yet. Set postgresql.restart_script_path (env: DBT_POSTGRESQL_RESTART_SCRIPT_PATH) to a custom restart script, or set postgresql.allow_restart=false (or unset DBT_POSTGRESQL_ALLOW_RESTART) to run the agent in monitoring/reload-only mode")
 	}
 
 	return pgConfig, nil

--- a/pkg/pg/config_test.go
+++ b/pkg/pg/config_test.go
@@ -27,6 +27,22 @@ func TestConfigFromViper_AllowRestartFromEnv(t *testing.T) {
 	assert.True(t, cfg.AllowRestart, "pgConfig.AllowRestart should reflect DBT_POSTGRESQL_ALLOW_RESTART")
 }
 
+// TestConfigFromViper_RestartScriptPathFromEnv locks in that the env var
+// DBT_POSTGRESQL_RESTART_SCRIPT_PATH populates pgConfig.RestartScriptPath via
+// the sub-viper unmarshal path.
+func TestConfigFromViper_RestartScriptPathFromEnv(t *testing.T) {
+	viper.Reset()
+	defer viper.Reset()
+
+	t.Setenv("DBT_POSTGRESQL_CONNECTION_URL", testConnectionURL)
+	t.Setenv("DBT_POSTGRESQL_RESTART_SCRIPT_PATH", "/opt/scripts/restart.sh")
+
+	cfg, err := ConfigFromViper(nil)
+	require.NoError(t, err)
+	assert.Equal(t, "/opt/scripts/restart.sh", cfg.RestartScriptPath,
+		"pgConfig.RestartScriptPath should reflect DBT_POSTGRESQL_RESTART_SCRIPT_PATH")
+}
+
 // TestConfigFromViper_GlobalViperSeesAllowRestartEnv is the regression
 // test for the bug where viper.Sub("postgresql").BindEnv(...) did not
 // propagate to the global viper, so viper.GetBool("postgresql.allow_restart")

--- a/pkg/pgprem/CONFIG.md
+++ b/pkg/pgprem/CONFIG.md
@@ -2,8 +2,13 @@
 ```yaml
 postgresql:
   connection_url: postgresql://user:password@localhost:5432/database # Database connection string
-  service_name: "postgresql-17" # (required for restart) name of your database service running under systemctl
+  service_name: "postgresql-17" # (required for restart unless `restart_script_path` is set) name of your database service running under systemctl
+  # restart_script_path: ""     # Optional. Path to an executable restart script. When set, restarts execute this
+                                # script directly (no shell, no arguments) instead of `systemctl restart`. Takes
+                                # precedence over `service_name`. The file must exist and be executable by the agent.
   allow_restart: false  # Allow the agent to restart PostgreSQL. Defaults to false.
+                        # When true, either `service_name` must be set or `restart_script_path` must point to an
+                        # existing executable script.
 
 dbtune:
   server_url: https://app.dbtune.com # DBtune server endpoint
@@ -29,5 +34,7 @@ export DBT_DBTUNE_DATABASE_ID=your-database-id
 # Your database specific
 export DBT_POSTGRESQL_CONNECTION_URL=postgresql://user:password@localhost:5432/database
 export DBT_POSTGRESQL_SERVICE_NAME=
-export DBT_POSTGRESQL_ALLOW_RESTART=false  # Set to true to allow PostgreSQL restarts
+# export DBT_POSTGRESQL_RESTART_SCRIPT_PATH=  # Optional. Path to an executable restart script. When set, restarts execute it directly. Takes precedence over SERVICE_NAME.
+export DBT_POSTGRESQL_ALLOW_RESTART=false  # Set to true to allow PostgreSQL restarts.
+                                           # When true, either SERVICE_NAME must be set or RESTART_SCRIPT_PATH must point to an existing executable.
 ```

--- a/pkg/pgprem/adapter.go
+++ b/pkg/pgprem/adapter.go
@@ -3,6 +3,7 @@ package pgprem
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 
 	"github.com/dbtuneai/agent/pkg/agent"
@@ -35,6 +36,30 @@ func CreateDefaultPostgreSQLAdapter() (*DefaultPostgreSQLAdapter, error) {
 	pgConfig, err := pg.ConfigFromViper(nil)
 	if err != nil {
 		return nil, err
+	}
+
+	if pgConfig.AllowRestart && pgConfig.ServiceName == "" && pgConfig.RestartScriptPath == "" {
+		return nil, fmt.Errorf(
+			"postgresql.allow_restart is true but neither postgresql.service_name nor postgresql.restart_script_path is configured. " +
+				"Set postgresql.service_name (env: DBT_POSTGRESQL_SERVICE_NAME) " +
+				"or set postgresql.restart_script_path (env: DBT_POSTGRESQL_RESTART_SCRIPT_PATH) to a custom restart script",
+		)
+	}
+
+	if pgConfig.RestartScriptPath != "" {
+		info, err := os.Stat(pgConfig.RestartScriptPath)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"postgresql.restart_script_path is set but %s is not accessible: %w",
+				pgConfig.RestartScriptPath, err,
+			)
+		}
+		if info.IsDir() {
+			return nil, fmt.Errorf("%s is a directory, expected an executable file", pgConfig.RestartScriptPath)
+		}
+		if info.Mode()&0o111 == 0 {
+			return nil, fmt.Errorf("%s is not executable (mode %s); chmod +x it", pgConfig.RestartScriptPath, info.Mode())
+		}
 	}
 
 	dbpool, err := pgPool.New(context.Background(), pgConfig.ConnectionURL)
@@ -158,8 +183,8 @@ func (adapter *DefaultPostgreSQLAdapter) ApplyConfig(ctx context.Context, propos
 	if err != nil {
 		return &agent.ConfigApplyError{Err: err}
 	}
-	if requiresRestart && adapter.pgConfig.ServiceName == "" {
-		return &agent.ConfigApplyError{Err: fmt.Errorf("service name not configured, refusing to apply: a restart is required to take effect")}
+	if requiresRestart && adapter.pgConfig.ServiceName == "" && adapter.pgConfig.RestartScriptPath == "" {
+		return &agent.ConfigApplyError{Err: fmt.Errorf("neither service name nor restart script configured, refusing to apply: a restart is required to take effect")}
 	}
 
 	for _, knob := range parsedKnobs {
@@ -169,9 +194,39 @@ func (adapter *DefaultPostgreSQLAdapter) ApplyConfig(ctx context.Context, propos
 		}
 	}
 
-	if requiresRestart {
-		// Restart the service
-		adapter.Logger().Warn("Restarting service")
+	if !requiresRestart {
+		// Reload database when everything is applied. KnobApplication=restart
+		// with no postmaster-context params falls through here too: the intent
+		// is treated as a hint, and we avoid a needless restart.
+		err := pg.ReloadConfig(adapter.pgDriver)
+		if err != nil {
+			return &agent.ConfigApplyError{Err: err}
+		}
+		return nil
+	}
+
+	// Restart the service
+	adapter.Logger().Warn("Restarting service")
+
+	if adapter.pgConfig.RestartScriptPath != "" {
+		// Execute the operator-provided restart script directly (no shell
+		// interpolation). The path comes from trusted config.
+		//
+		// Contract: the script MUST signal success with exit code 0 and failure
+		// with any non-zero exit code. Output written to stdout/stderr is treated
+		// as diagnostic only (logged on failure) and does not affect the
+		// success/failure decision.
+		cmd := exec.Command(adapter.pgConfig.RestartScriptPath) //nolint:gosec // path is from trusted config
+		output, err := cmd.CombinedOutput()
+		exitCode := cmd.ProcessState.ExitCode() // -1 if the process never ran
+		if err != nil || exitCode != 0 {
+			adapter.Logger().Warnf("restart script %s exited with code %d; output: %s",
+				adapter.pgConfig.RestartScriptPath, exitCode, string(output))
+			return &agent.ConfigApplyError{Err: fmt.Errorf("restart script %s failed (exit code %d): %w",
+				adapter.pgConfig.RestartScriptPath, exitCode, err)}
+		}
+		adapter.Logger().Warnf("Service restarted via %s (exit code 0).", adapter.pgConfig.RestartScriptPath)
+	} else {
 		// Execute systemctl restart command if it fails try executing it with sudo
 		cmd := exec.Command("systemctl", "restart", adapter.pgConfig.ServiceName) //nolint:gosec // ServiceName is from trusted config
 		if err := cmd.Run(); err != nil {
@@ -185,19 +240,10 @@ func (adapter *DefaultPostgreSQLAdapter) ApplyConfig(ctx context.Context, propos
 		} else {
 			adapter.Logger().Warn("Service restarted.")
 		}
+	}
 
-		err := pg.WaitPostgresReady(adapter.pgDriver)
-		if err != nil {
-			return &agent.ConfigApplyError{Err: fmt.Errorf("failed to wait for PostgreSQL to be back online: %w", err)}
-		}
-	} else {
-		// Reload database when everything is applied. KnobApplication=restart
-		// with no postmaster-context params falls through here too: the intent
-		// is treated as a hint, and we avoid a needless restart.
-		err := pg.ReloadConfig(adapter.pgDriver)
-		if err != nil {
-			return &agent.ConfigApplyError{Err: err}
-		}
+	if err := pg.WaitPostgresReady(adapter.pgDriver); err != nil {
+		return &agent.ConfigApplyError{Err: fmt.Errorf("failed to wait for PostgreSQL to be back online: %w", err)}
 	}
 	return nil
 }

--- a/pkg/pgprem/adapter_integration_test.go
+++ b/pkg/pgprem/adapter_integration_test.go
@@ -265,7 +265,7 @@ func TestIntegration_Pgprem_ApplyConfig_Restart_NoServiceName(t *testing.T) {
 
 	err := adapter.ApplyConfig(context.Background(), proposed)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "service name not configured")
+	assert.Contains(t, err.Error(), "neither service name nor restart script configured")
 
 	assert.Empty(t, autoConfSetting(t, pool, "shared_buffers"),
 		"no ALTER SYSTEM should have been issued when the agent cannot perform the required restart")

--- a/pkg/pgprem/adapter_integration_test.go
+++ b/pkg/pgprem/adapter_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"testing"
 	"time"
@@ -162,6 +163,28 @@ func newAdapter(t *testing.T, pool *pgxpool.Pool, serviceName string) *DefaultPo
 	}
 	adapter.WithLogger(logrus.New())
 	return adapter
+}
+
+func newAdapterWithRestartScript(t *testing.T, pool *pgxpool.Pool, scriptPath string) *DefaultPostgreSQLAdapter {
+	t.Helper()
+	adapter := &DefaultPostgreSQLAdapter{
+		pgDriver: pool,
+		pgConfig: pg.Config{
+			ConnectionURL:     pgpremConnStr,
+			RestartScriptPath: scriptPath,
+		},
+	}
+	adapter.WithLogger(logrus.New())
+	return adapter
+}
+
+// writeRestartScript writes an executable /bin/sh script (body appended after
+// the shebang) into a temp dir and returns its path.
+func writeRestartScript(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "restart.sh")
+	require.NoError(t, os.WriteFile(path, []byte("#!/bin/sh\n"+body+"\n"), 0o755))
+	return path
 }
 
 // TestIntegration_Pgprem_ApplyConfig_Reload_NonRestartParam confirms the
@@ -364,5 +387,62 @@ func TestIntegration_Pgprem_ApplyConfig_Restart_AttemptsSystemctl(t *testing.T) 
 	// should be present in postgresql.auto.conf even though the restart
 	// itself failed. (This mirrors the production behaviour: by the time
 	// we attempt the restart, the file has been mutated.)
+	assert.Equal(t, "4096", autoConfSetting(t, pool, "shared_buffers"))
+}
+
+// TestIntegration_Pgprem_ApplyConfig_Restart_ViaScript exercises the custom
+// restart-script branch end to end: with restart_script_path set, a
+// restart-required parameter is ALTER SYSTEM'd, the script is executed, and a
+// zero exit code is treated as a successful restart. The script touches a
+// sentinel file so we can prove it actually ran. PostgreSQL is never really
+// restarted (the testcontainer stays up), which also confirms the post-restart
+// readiness check passes against the live database.
+func TestIntegration_Pgprem_ApplyConfig_Restart_ViaScript(t *testing.T) {
+	setAllowRestart(t, true)
+	pool := newPool(t)
+	t.Cleanup(func() { resetAutoConf(t, pool, "shared_buffers") })
+
+	sentinel := filepath.Join(t.TempDir(), "ran")
+	adapter := newAdapterWithRestartScript(t, pool, writeRestartScript(t, "echo restarted > "+sentinel))
+
+	proposed := &agent.ProposedConfigResponse{
+		Config: []agent.PGConfigRow{
+			{Name: "shared_buffers", Setting: int64(8192), Vartype: "integer"},
+		},
+		KnobsOverrides:  []string{"shared_buffers"},
+		KnobApplication: agent.KnobApplicationRestart,
+	}
+
+	require.NoError(t, adapter.ApplyConfig(context.Background(), proposed))
+
+	assert.FileExists(t, sentinel, "the restart script should have been executed")
+	assert.Equal(t, "8192", autoConfSetting(t, pool, "shared_buffers"),
+		"ALTER SYSTEM should have landed before the restart script ran")
+}
+
+// TestIntegration_Pgprem_ApplyConfig_RestartScript_Fails asserts that a
+// non-zero exit code from the custom restart script is surfaced as an error,
+// mirroring the systemctl-failure path. As there, the ALTER SYSTEM mutation has
+// already landed by the time the restart is attempted.
+func TestIntegration_Pgprem_ApplyConfig_RestartScript_Fails(t *testing.T) {
+	setAllowRestart(t, true)
+	pool := newPool(t)
+	t.Cleanup(func() { resetAutoConf(t, pool, "shared_buffers") })
+
+	adapter := newAdapterWithRestartScript(t, pool, writeRestartScript(t, "echo boom >&2\nexit 3"))
+
+	proposed := &agent.ProposedConfigResponse{
+		Config: []agent.PGConfigRow{
+			{Name: "shared_buffers", Setting: int64(4096), Vartype: "integer"},
+		},
+		KnobsOverrides:  []string{"shared_buffers"},
+		KnobApplication: agent.KnobApplicationRestart,
+	}
+
+	err := adapter.ApplyConfig(context.Background(), proposed)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "restart script")
+	assert.Contains(t, err.Error(), "failed")
+
 	assert.Equal(t, "4096", autoConfSetting(t, pool, "shared_buffers"))
 }


### PR DESCRIPTION
This PR supersedes #148 .

The idea is: sometimes the restarting mechanism is more complicated than just using `systemctl`. In this PR we allow for specifying a custom path for a restart script that gets called when the user requires a more sophisticated restart.

This PR addresses the feedback received in #148 , changing the hard-coded script location for one that the user can specify. For it to work, the user needs to specify two things: the usual `ALLOW_RESTARTS` flag, and now a `RESTART_SCRIPT_PATH`.