### PR TITLE
fix: schema-qualify pg_stat_statements to handle custom search_path

### DIFF
--- a/pkg/pg/collectors.go
+++ b/pkg/pg/collectors.go
@@ -24,7 +24,7 @@ SELECT
 	calls,
 	total_exec_time,
 	rows
-FROM pg_stat_statements
+FROM public.pg_stat_statements
 WHERE NOT starts_with(query, '%s')
   AND query !~* '^\\s*(BEGIN|COMMIT|ROLLBACK|SET |SHOW |SELECT (pg_|\\$1$|version\\s*\\(\\s*\\)))\\s*;?\\s*$'
 `, utils.DBtuneQueryPrefix)
@@ -42,7 +42,7 @@ SELECT
 	rows,
 	LEFT(query, %%d) as query,
 	LENGTH(query)
-FROM pg_stat_statements
+FROM public.pg_stat_statements
 WHERE NOT starts_with(query, '%s')
   AND query !~* '^\\s*(BEGIN|COMMIT|ROLLBACK|SET |SHOW |SELECT (pg_|\\$1$|version\\s*\\(\\s*\\)))\\s*;?\\s*$'
 `, utils.DBtuneQueryPrefix)

--- a/pkg/pg/queries.go
+++ b/pkg/pg/queries.go
@@ -186,7 +186,7 @@ func Select1(pgPool *pgxpool.Pool) error {
 }
 
 const CheckPGStatStatementsQuery = `
-SELECT COUNT(*) FROM pg_stat_statements;
+SELECT COUNT(*) FROM public.pg_stat_statements;
 `
 
 func CheckPGStatStatements(pgPool *pgxpool.Pool) error {

--- a/pkg/pg/queries/pg_stat_statements.go
+++ b/pkg/pg/queries/pg_stat_statements.go
@@ -234,7 +234,7 @@ func buildPgStatStatementsQuery(includeQueries bool, maxQueryTextLength int, ext
 		)
 	}
 
-	return fmt.Sprintf("SELECT %s\nFROM pg_stat_statements\n%s",
+	return fmt.Sprintf("SELECT %s\nFROM public.pg_stat_statements\n%s",
 		strings.Join(cols, ", "), pgStatStatementsFilter)
 }
 


### PR DESCRIPTION
The agent queries `pg_stat_statements` without a schema prefix. If the connecting user's `search_path` doesn't include `public`, PostgreSQL can't resolve the relation and the agent fails at startup.
  
The workaround was to manually run `ALTER USER x SET search_path TO public` on the database -- this removes that requirement. 