### PR TITLE
feat: collect Postgres cluster identity in server_uptime collector (DBT-2347)

### DIFF
--- a/pkg/pg/queries/collectors_integration_test.go
+++ b/pkg/pg/queries/collectors_integration_test.go
@@ -528,7 +528,35 @@ func TestDatabaseSize_ReturnsData(t *testing.T) {
 func TestUptimeMinutes_ReturnsData(t *testing.T) {
 	forEachPG(t, func(t *testing.T, inst pgInstance) {
 		c := UptimeMinutesCollector(inst.pool, noopPrepareCtx)
-		requireRows(t, c)
+		result, err := c.Collect(context.Background())
+		if err != nil {
+			t.Fatalf("Collect() error: %v", err)
+		}
+		var p Payload[UptimeMinutesRow]
+		if err := json.Unmarshal(result.JSON, &p); err != nil {
+			t.Fatalf("failed to parse result: %v", err)
+		}
+		if len(p.Rows) != 1 {
+			t.Fatalf("expected 1 row, got %d", len(p.Rows))
+		}
+		row := p.Rows[0]
+		if row.UptimeMinutes <= 0 {
+			t.Fatalf("expected uptime_minutes > 0, got %f", row.UptimeMinutes)
+		}
+		// pg_control_system()/pg_control_checkpoint() are callable by any
+		// role on self-hosted PG, so identity must be present here.
+		if row.SystemIdentifier == nil || *row.SystemIdentifier == "" {
+			t.Fatal("expected system_identifier to be set")
+		}
+		if row.TimelineID == nil || *row.TimelineID < 1 {
+			t.Fatal("expected timeline_id >= 1")
+		}
+		if row.PostmasterStartTime == nil {
+			t.Fatal("expected postmaster_start_time to be set")
+		}
+		if _, err := time.Parse(time.RFC3339, *row.PostmasterStartTime); err != nil {
+			t.Fatalf("postmaster_start_time not RFC3339: %v", err)
+		}
 	})
 }
 

--- a/pkg/pg/queries/scanner_tags_test.go
+++ b/pkg/pg/queries/scanner_tags_test.go
@@ -15,7 +15,7 @@ import (
 // name, which silently fails to populate the field when the two don't match
 // (e.g., DataName → "dataname" vs column "datname").
 //
-// Excluded: PgStatsRow (uses manual rows.Scan, not pgxutil.Scanner).
+// Excluded: PgStatsRow, UptimeMinutesRow (manual rows.Scan, not pgxutil.Scanner).
 var scannerBackedTypes = []interface{}{
 	AutovacuumCountRow{},
 	ConnectionStatsRow{},
@@ -54,7 +54,6 @@ var scannerBackedTypes = []interface{}{
 	PgStatWalReceiverRow{},
 	PgStatioUserIndexesRow{},
 	PgStatioUserTablesRow{},
-	UptimeMinutesRow{},
 	WaitEventRow{},
 }
 

--- a/pkg/pg/queries/uptime.go
+++ b/pkg/pg/queries/uptime.go
@@ -45,6 +45,9 @@ SELECT (pg_control_system()).system_identifier AS system_identifier,
 // clusterIdentityRefreshInterval bounds how often the pg_control_* query
 // runs. Identity only changes on restart/restore/failover, so a few minutes
 // of staleness is fine and avoids an extra round-trip on every 5s tick.
+// A change in the observed postmaster start time invalidates the cache
+// immediately, so a restart/restore/failover never pairs a fresh start time
+// with pre-failover identity.
 const clusterIdentityRefreshInterval = 10 * time.Minute
 
 type clusterIdentity struct {
@@ -61,10 +64,18 @@ type clusterIdentityCache struct {
 	pool          *pgxpool.Pool
 	cached        *clusterIdentity
 	lastAttempt   time.Time
+	lastStartTime time.Time
 	loggedFailure bool
 }
 
-func (c *clusterIdentityCache) get(ctx context.Context) *clusterIdentity {
+func (c *clusterIdentityCache) get(ctx context.Context, postmasterStartTime time.Time) *clusterIdentity {
+	if !postmasterStartTime.IsZero() && !postmasterStartTime.Equal(c.lastStartTime) {
+		if !c.lastStartTime.IsZero() {
+			c.lastAttempt = time.Time{}
+			c.cached = nil
+		}
+		c.lastStartTime = postmasterStartTime
+	}
 	if !c.lastAttempt.IsZero() && time.Since(c.lastAttempt) < clusterIdentityRefreshInterval {
 		return c.cached
 	}
@@ -83,12 +94,17 @@ func (c *clusterIdentityCache) get(ctx context.Context) *clusterIdentity {
 	}
 	c.loggedFailure = false
 	c.cached = &clusterIdentity{
-		// system_identifier is a uint64 exposed through bigint; reinterpret
-		// the bits so values above MaxInt64 render as unsigned decimal.
-		systemIdentifier: strconv.FormatUint(uint64(systemIdentifier), 10), //nolint:gosec // intentional bit reinterpretation
+		systemIdentifier: formatSystemIdentifier(systemIdentifier),
 		timelineID:       timelineID,
 	}
 	return c.cached
+}
+
+// formatSystemIdentifier renders pg_control_system().system_identifier — a
+// uint64 exposed through bigint — by reinterpreting the bits so values above
+// MaxInt64 render as unsigned decimal.
+func formatSystemIdentifier(v int64) string {
+	return strconv.FormatUint(uint64(v), 10) //nolint:gosec // intentional bit reinterpretation
 }
 
 func UptimeMinutesCollector(pool *pgxpool.Pool, prepareCtx PrepareCtx) CatalogCollector {
@@ -115,7 +131,7 @@ func UptimeMinutesCollector(pool *pgxpool.Pool, prepareCtx PrepareCtx) CatalogCo
 				started := postmasterStartTime.UTC().Format(time.RFC3339)
 				row.PostmasterStartTime = &started
 			}
-			if id := identity.get(ctx); id != nil {
+			if id := identity.get(ctx, postmasterStartTime); id != nil {
 				row.SystemIdentifier = &id.systemIdentifier
 				row.TimelineID = &id.timelineID
 			}

--- a/pkg/pg/queries/uptime.go
+++ b/pkg/pg/queries/uptime.go
@@ -2,18 +2,31 @@ package queries
 
 // UptimeMinutes reports how long the PostgreSQL server has been running,
 // in minutes, by computing the difference between the current timestamp and
-// pg_postmaster_start_time().
+// pg_postmaster_start_time(). The payload also carries cluster identity —
+// system identifier, timeline ID and postmaster start time — so the backend
+// can distinguish restarts, restores and failovers (DBT-2347). Identity
+// fields are optional: they are omitted when unavailable.
 //
 // https://www.postgresql.org/docs/current/functions-info.html#FUNCTIONS-INFO-SESSION
+// https://www.postgresql.org/docs/current/functions-admin.html#FUNCTIONS-ADMIN-CONTROLDATA
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strconv"
 	"time"
 
+	"github.com/dbtuneai/agent/pkg/internal/utils"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 type UptimeMinutesRow struct {
-	UptimeMinutes DoublePrecision `json:"uptime_minutes" db:"uptime_minutes"`
+	UptimeMinutes       float64 `json:"uptime_minutes"`
+	SystemIdentifier    *string `json:"system_identifier,omitempty"`
+	TimelineID          *int64  `json:"timeline_id,omitempty"`
+	PostmasterStartTime *string `json:"postmaster_start_time,omitempty"`
 }
 
 const (
@@ -21,8 +34,100 @@ const (
 	UptimeMinutesInterval = 5 * time.Second
 )
 
-const uptimeMinutesQuery = `SELECT EXTRACT(EPOCH FROM (current_timestamp - pg_postmaster_start_time())) / 60 AS uptime_minutes`
+const uptimeMinutesQuery = `
+SELECT EXTRACT(EPOCH FROM (current_timestamp - pg_postmaster_start_time())) / 60 AS uptime_minutes,
+       pg_postmaster_start_time() AS postmaster_start_time`
+
+const clusterIdentityQuery = `
+SELECT (pg_control_system()).system_identifier AS system_identifier,
+       (pg_control_checkpoint()).timeline_id AS timeline_id`
+
+// clusterIdentityRefreshInterval bounds how often the pg_control_* query
+// runs. Identity only changes on restart/restore/failover, so a few minutes
+// of staleness is fine and avoids an extra round-trip on every 5s tick.
+const clusterIdentityRefreshInterval = 10 * time.Minute
+
+type clusterIdentity struct {
+	systemIdentifier string
+	timelineID       int64
+}
+
+// clusterIdentityCache lazily queries and caches the cluster identity.
+// pg_control_system()/pg_control_checkpoint() can be permission-restricted
+// on managed services (RDS/Aurora/CloudSQL) or missing on old versions; on
+// failure the identity is omitted and the failure logged once per streak.
+// Not safe for concurrent use — each collector runs in a single goroutine.
+type clusterIdentityCache struct {
+	pool          *pgxpool.Pool
+	cached        *clusterIdentity
+	lastAttempt   time.Time
+	loggedFailure bool
+}
+
+func (c *clusterIdentityCache) get(ctx context.Context) *clusterIdentity {
+	if !c.lastAttempt.IsZero() && time.Since(c.lastAttempt) < clusterIdentityRefreshInterval {
+		return c.cached
+	}
+	c.lastAttempt = time.Now()
+	var systemIdentifier int64
+	var timelineID int64
+	err := utils.QueryRowWithPrefix(c.pool, ctx, clusterIdentityQuery).Scan(&systemIdentifier, &timelineID)
+	if err != nil {
+		if !c.loggedFailure {
+			slog.Warn("cluster identity unavailable; omitting system_identifier/timeline_id from server_uptime",
+				"error", err)
+			c.loggedFailure = true
+		}
+		c.cached = nil
+		return nil
+	}
+	c.loggedFailure = false
+	c.cached = &clusterIdentity{
+		// system_identifier is a uint64 exposed through bigint; reinterpret
+		// the bits so values above MaxInt64 render as unsigned decimal.
+		systemIdentifier: strconv.FormatUint(uint64(systemIdentifier), 10), //nolint:gosec // intentional bit reinterpretation
+		timelineID:       timelineID,
+	}
+	return c.cached
+}
 
 func UptimeMinutesCollector(pool *pgxpool.Pool, prepareCtx PrepareCtx) CatalogCollector {
-	return NewCollector[UptimeMinutesRow](pool, prepareCtx, UptimeMinutesName, UptimeMinutesInterval, uptimeMinutesQuery)
+	identity := &clusterIdentityCache{pool: pool}
+	return CatalogCollector{
+		Name:     UptimeMinutesName,
+		Interval: UptimeMinutesInterval,
+		Collect: func(ctx context.Context) (*CollectResult, error) {
+			ctx, err := prepareCtx(ctx)
+			if err != nil {
+				return nil, err
+			}
+			collectedAt := time.Now().UTC()
+			var uptimeMinutes float64
+			var postmasterStartTime time.Time
+			err = utils.QueryRowWithPrefix(pool, ctx, uptimeMinutesQuery).
+				Scan(&uptimeMinutes, &postmasterStartTime)
+			if err != nil {
+				return nil, fmt.Errorf("failed to query %s: %w", UptimeMinutesName, err)
+			}
+
+			row := UptimeMinutesRow{UptimeMinutes: uptimeMinutes}
+			if !postmasterStartTime.IsZero() {
+				started := postmasterStartTime.UTC().Format(time.RFC3339)
+				row.PostmasterStartTime = &started
+			}
+			if id := identity.get(ctx); id != nil {
+				row.SystemIdentifier = &id.systemIdentifier
+				row.TimelineID = &id.timelineID
+			}
+
+			data, err := json.Marshal(&Payload[UptimeMinutesRow]{
+				CollectedAt: collectedAt,
+				Rows:        []UptimeMinutesRow{row},
+			})
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal %s: %w", UptimeMinutesName, err)
+			}
+			return &CollectResult{JSON: data}, nil
+		},
+	}
 }

--- a/pkg/pg/queries/uptime_test.go
+++ b/pkg/pg/queries/uptime_test.go
@@ -1,0 +1,61 @@
+package queries
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestUptimeMinutesRow_OptionalFieldsOmittedWhenUnset(t *testing.T) {
+	data, err := json.Marshal(UptimeMinutesRow{UptimeMinutes: 12.5})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(data)
+	if got != `{"uptime_minutes":12.5}` {
+		t.Fatalf("expected optional fields omitted, got %s", got)
+	}
+}
+
+func TestUptimeMinutesRow_OptionalFieldsPresentWhenSet(t *testing.T) {
+	sysID := "7294956156579818536"
+	timelineID := int64(3)
+	started := "2026-07-27T10:15:00Z"
+	data, err := json.Marshal(UptimeMinutesRow{
+		UptimeMinutes:       1.0,
+		SystemIdentifier:    &sysID,
+		TimelineID:          &timelineID,
+		PostmasterStartTime: &started,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(data)
+	for _, want := range []string{
+		`"system_identifier":"7294956156579818536"`,
+		`"timeline_id":3`,
+		`"postmaster_start_time":"2026-07-27T10:15:00Z"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %s in %s", want, got)
+		}
+	}
+}
+
+func TestClusterIdentityCache_ServesCachedWithinRefreshInterval(t *testing.T) {
+	id := &clusterIdentity{systemIdentifier: "42", timelineID: 1}
+	// pool is nil — a query attempt would panic, proving the cache is served.
+	c := &clusterIdentityCache{cached: id, lastAttempt: time.Now()}
+	if got := c.get(context.Background()); got != id {
+		t.Fatalf("expected cached identity, got %v", got)
+	}
+}
+
+func TestClusterIdentityCache_ServesNilFailureResultWithinRefreshInterval(t *testing.T) {
+	c := &clusterIdentityCache{cached: nil, lastAttempt: time.Now()}
+	if got := c.get(context.Background()); got != nil {
+		t.Fatalf("expected nil identity, got %v", got)
+	}
+}

--- a/pkg/pg/queries/uptime_test.go
+++ b/pkg/pg/queries/uptime_test.go
@@ -48,14 +48,52 @@ func TestClusterIdentityCache_ServesCachedWithinRefreshInterval(t *testing.T) {
 	id := &clusterIdentity{systemIdentifier: "42", timelineID: 1}
 	// pool is nil — a query attempt would panic, proving the cache is served.
 	c := &clusterIdentityCache{cached: id, lastAttempt: time.Now()}
-	if got := c.get(context.Background()); got != id {
+	if got := c.get(context.Background(), time.Time{}); got != id {
 		t.Fatalf("expected cached identity, got %v", got)
 	}
 }
 
 func TestClusterIdentityCache_ServesNilFailureResultWithinRefreshInterval(t *testing.T) {
 	c := &clusterIdentityCache{cached: nil, lastAttempt: time.Now()}
-	if got := c.get(context.Background()); got != nil {
+	if got := c.get(context.Background(), time.Time{}); got != nil {
 		t.Fatalf("expected nil identity, got %v", got)
+	}
+}
+
+func TestClusterIdentityCache_ServesCachedWhenPostmasterStartTimeUnchanged(t *testing.T) {
+	started := time.Date(2026, 7, 27, 10, 0, 0, 0, time.UTC)
+	id := &clusterIdentity{systemIdentifier: "42", timelineID: 1}
+	c := &clusterIdentityCache{cached: id, lastAttempt: time.Now(), lastStartTime: started}
+	if got := c.get(context.Background(), started); got != id {
+		t.Fatalf("expected cached identity, got %v", got)
+	}
+}
+
+func TestClusterIdentityCache_InvalidatesWhenPostmasterStartTimeChanges(t *testing.T) {
+	started := time.Date(2026, 7, 27, 10, 0, 0, 0, time.UTC)
+	c := &clusterIdentityCache{
+		cached:        &clusterIdentity{systemIdentifier: "42", timelineID: 1},
+		lastAttempt:   time.Now(),
+		lastStartTime: started,
+	}
+	// pool is nil — the refresh query panics, proving the changed start time
+	// bypassed the lastAttempt gate instead of serving pre-failover identity.
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected an immediate refresh attempt, got cached identity")
+		}
+		if c.cached != nil {
+			t.Fatalf("expected cached identity dropped, got %v", c.cached)
+		}
+	}()
+	c.get(context.Background(), started.Add(time.Hour))
+}
+
+func TestFormatSystemIdentifier(t *testing.T) {
+	if got := formatSystemIdentifier(7294956156579818536); got != "7294956156579818536" {
+		t.Fatalf("expected positive value unchanged, got %s", got)
+	}
+	if got := formatSystemIdentifier(-1); got != "18446744073709551615" {
+		t.Fatalf("expected -1 reinterpreted as max uint64, got %s", got)
 	}
 }


### PR DESCRIPTION
Agent half of DBT-2347 (part of the DBT-2337 fix plan: detect database rebuilds/restores so the platform can invalidate stale derived "since" timestamps).

## What

The `server_uptime` collector now also reports Postgres cluster identity as **optional** payload fields (inside the existing single row, envelope unchanged):

- `system_identifier` — string, decimal of the uint64 from `pg_control_system()` (string because uint64 exceeds JSON-safe integers; negative int64 bit-reinterpreted via `formatSystemIdentifier`)
- `timeline_id` — int, from `pg_control_checkpoint()`
- `postmaster_start_time` — RFC3339 UTC, from `pg_postmaster_start_time()` (rides the existing 5s uptime query — zero extra round-trips)

Fields are omitted entirely when unavailable — old platforms drop unknown keys, so this is safe to ship independently of the platform PR.

## Design

- `system_identifier`/`timeline_id` come from a separate control query behind a 10-minute cache (~1 extra round-trip per 120 ticks). The cache is invalidated immediately when the observed `postmaster_start_time` changes, so a failover/restore never pairs a fresh start time with pre-failover identity.
- Graceful degradation: on any error (restricted managed services, old PG), identity fields are dropped, one warn per failure streak, `uptime_minutes` unaffected. If only `pg_postmaster_start_time()` is available, only it is sent.
- Collector name, 5s interval, config keys, and envelope are unchanged — existing customer configs unaffected.

## Verification

`go build`, `go vet` (incl. integration tag), `gofmt`, `golangci-lint` clean; unit tests for cache gating, invalidation-on-start-time-change, omitempty marshalling, and the uint64 conversion all pass.
