### PR TITLE
fix(ci): migrate missed docker/docker import to moby/moby

### DIFF
--- a/pkg/pg/database_system_info_integration_test.go
+++ b/pkg/pg/database_system_info_integration_test.go
@@ -7,14 +7,15 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/netip"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/dbtuneai/agent/pkg/metrics"
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/go-connections/nat"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/network"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	tclog "github.com/testcontainers/testcontainers-go/log"
@@ -49,9 +50,9 @@ func TestMain(m *testing.M) {
 		testcontainers.CustomizeRequest(testcontainers.GenericContainerRequest{
 			ContainerRequest: testcontainers.ContainerRequest{
 				HostConfigModifier: func(hc *container.HostConfig) {
-					hc.PortBindings = nat.PortMap{
-						"5432/tcp": []nat.PortBinding{
-							{HostIP: "127.0.0.1", HostPort: dbSysInfoIntegrationPort},
+					hc.PortBindings = network.PortMap{
+						network.MustParsePort("5432/tcp"): []network.PortBinding{
+							{HostIP: netip.MustParseAddr("127.0.0.1"), HostPort: dbSysInfoIntegrationPort},
 						},
 					}
 				},


### PR DESCRIPTION
PR #182 migrated docker/docker → moby/moby but missed `pkg/pg/database_system_info_integration_test.go` — it sits behind the `integration` build tag, so regular builds and lint never compiled it. Since #182 merged, every PR fails both the "Verify go.mod is tidy" check (tidy tries to resolve `docker/docker/api`, whose module path upstream is now `moby/moby/api`) and the integration suite (`FAIL github.com/dbtuneai/agent/pkg/pg [setup failed]`).

This applies the exact same import/call-site mapping #182 used elsewhere (`nat.PortMap` → `network.PortMap` with `netip.MustParseAddr`).

Verified: `go mod tidy` zero diff, `go build ./...`, `go vet -tags integration ./pkg/pg/...`, and full test-binary compile (`go test -tags integration -c`) all clean.

Unblocks #183 (and any other open PR).