### PR TITLE
fix: don't kill the agent on Cloud Monitoring API errors

### DIFF
--- a/pkg/cloudsql/queries.go
+++ b/pkg/cloudsql/queries.go
@@ -3,7 +3,6 @@ package cloudsql
 import (
 	"errors"
 	"fmt"
-	"log"
 	"time"
 
 	"cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
@@ -123,9 +122,8 @@ func getLatestMetricValue(cloudMonitoringClient *CloudMonitoringClient, projectI
 	if errors.Is(err, iterator.Done) {
 		return monitoringpb.TypedValue{}, fmt.Errorf("Oh no, we didn't get any results!")
 	}
-	// TODO: what other errors can this actually return?
 	if err != nil {
-		log.Fatalf("Could not read time series value: %v", err)
+		return monitoringpb.TypedValue{}, fmt.Errorf("could not read time series value: %w", err)
 	}
 
 	// the iterator should end here as our filters should give a single time series


### PR DESCRIPTION
## Problem

`getLatestMetricValue` calls `log.Fatalf` on any non-`iterator.Done` error from `ListTimeSeries`:

```go
// pkg/cloudsql/queries.go
resp, err := it.Next()
if errors.Is(err, iterator.Done) {
	return monitoringpb.TypedValue{}, fmt.Errorf("Oh no, we didn't get any results!")
}
// TODO: what other errors can this actually return?
if err != nil {
	log.Fatalf("Could not read time series value: %v", err)  // os.Exit(1)
}
```

This runs on every Cloud SQL metrics tick (`CloudSQLHardwareInfo` calls it ~10x per collection). A transient GCP error (throttle, 503, expired credentials, network blip) takes the whole agent process down.

It is the only runtime `log.Fatalf` on a collection path. Every other adapter returns the error and lets the runner log it and retry on the next tick.

## Fix

```go
if err != nil {
	return monitoringpb.TypedValue{}, fmt.Errorf("could not read time series value: %w", err)
}
```

Callers in `pkg/cloudsql/collectors.go` already handle this shape (`logger.Errorf` then fall through to the zero value), same as the existing `iterator.Done` and "Too many metrics returned" branches. Net effect: the sample is skipped and logged, the agent keeps running, next tick retries.

Dropped the stale `// TODO: what other errors can this actually return?` since the answer no longer changes the behaviour, and the now-unused `log` import.

## Testing

- `go build ./...`, `go vet ./pkg/cloudsql/...`
- `go test ./pkg/cloudsql/... ./pkg/agent/... ./pkg/runner/...` pass
- `golangci-lint run ./pkg/cloudsql/...` clean

Note: the `deadcode` pre-commit hook was skipped. It fails on a clean checkout of `main` too (`packages require newer Go version go1.25 (application built with go1.24)`), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)