### PR TITLE
fix: fall back to unknown when platform version is blank

### DIFF
--- a/pkg/patroni/adapter.go
+++ b/pkg/patroni/adapter.go
@@ -708,8 +708,11 @@ func (adapter *PatroniAdapter) GetSystemInfo(ctx context.Context) ([]metrics.Fla
 	if err != nil {
 		return nil, err
 	}
-	// gopsutil can return an empty PlatformVersion on some Windows builds; the
-	// backend rejects a blank string for this field.
+	// gopsutil can return an empty Platform/PlatformVersion on some Windows
+	// builds; the backend rejects a blank string for either field.
+	if hostInfo.Platform == "" {
+		hostInfo.Platform = "unknown"
+	}
 	if hostInfo.PlatformVersion == "" {
 		hostInfo.PlatformVersion = "unknown"
 	}

--- a/pkg/patroni/adapter.go
+++ b/pkg/patroni/adapter.go
@@ -708,6 +708,11 @@ func (adapter *PatroniAdapter) GetSystemInfo(ctx context.Context) ([]metrics.Fla
 	if err != nil {
 		return nil, err
 	}
+	// gopsutil can return an empty PlatformVersion on some Windows builds; the
+	// backend rejects a blank string for this field.
+	if hostInfo.PlatformVersion == "" {
+		hostInfo.PlatformVersion = "unknown"
+	}
 
 	noCPUs, err := cpu.Counts(true)
 	if err != nil {

--- a/pkg/pgprem/adapter.go
+++ b/pkg/pgprem/adapter.go
@@ -123,6 +123,11 @@ func (adapter *DefaultPostgreSQLAdapter) GetSystemInfo(_ context.Context) ([]met
 	if err != nil {
 		return nil, err
 	}
+	// gopsutil can return an empty PlatformVersion on some Windows builds; the
+	// backend rejects a blank string for this field.
+	if hostInfo.PlatformVersion == "" {
+		hostInfo.PlatformVersion = "unknown"
+	}
 
 	noCPUs, err := cpu.Counts(true)
 	if err != nil {

--- a/pkg/pgprem/adapter.go
+++ b/pkg/pgprem/adapter.go
@@ -123,8 +123,11 @@ func (adapter *DefaultPostgreSQLAdapter) GetSystemInfo(_ context.Context) ([]met
 	if err != nil {
 		return nil, err
 	}
-	// gopsutil can return an empty PlatformVersion on some Windows builds; the
-	// backend rejects a blank string for this field.
+	// gopsutil can return an empty Platform/PlatformVersion on some Windows
+	// builds; the backend rejects a blank string for either field.
+	if hostInfo.Platform == "" {
+		hostInfo.Platform = "unknown"
+	}
 	if hostInfo.PlatformVersion == "" {
 		hostInfo.PlatformVersion = "unknown"
 	}


### PR DESCRIPTION
gopsutil can return an empty PlatformVersion on some Windows builds,
which the backend rejects, failing the entire system info payload.

- Fixes system info failing to send on Windows when gopsutil's PlatformVersion comes back empty — the backend rejects blank strings, which was failing the whole payload (agent version, PG version, memory, CPU all missing from the dashboard as a result)
- Not PG-version-related — purely a Windows OS-detection quirk in gopsutil
- Applied the same fallback to both pgprem and patroni adapters (same bug pattern in both)