### PR TITLE
feat: sends bounds with the config

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -53,6 +53,10 @@ type PGConfigRow struct {
 	Unit    interface{} `json:"unit"`
 	Vartype string      `json:"vartype"`
 	Context string      `json:"context"`
+	// Bounds verbatim from pg_settings, in the unit named by Unit. NULL for
+	// bool/string/enum vartypes; the backend owns parsing and conversion.
+	MinVal *string `json:"min_val,omitempty"`
+	MaxVal *string `json:"max_val,omitempty"`
 }
 
 // GetSettingValue returns the setting value in its appropriate type and format

--- a/pkg/pg/queries.go
+++ b/pkg/pg/queries.go
@@ -154,7 +154,8 @@ func GetActiveConfig(
 
 // settingsToConfigRows converts raw PgSettingsRow values into the
 // ConfigArraySchema consumed by the tuning loop. Numeric vartypes
-// have InferNumericType applied; NULL units become nil.
+// have InferNumericType applied; NULL units become nil. min_val/max_val
+// are relayed verbatim as strings so the backend owns unit conversion.
 func settingsToConfigRows(settings []queries.PgSettingsRow) agent.ConfigArraySchema {
 	configRows := make(agent.ConfigArraySchema, 0, len(settings))
 	for _, s := range settings {
@@ -174,9 +175,20 @@ func settingsToConfigRows(settings []queries.PgSettingsRow) agent.ConfigArraySch
 			Unit:    unit,
 			Vartype: string(s.Vartype),
 			Context: string(s.Context),
+			MinVal:  textToStringPtr(s.MinVal),
+			MaxVal:  textToStringPtr(s.MaxVal),
 		})
 	}
 	return configRows
+}
+
+// textToStringPtr converts a nullable pg text column to *string, preserving NULL.
+func textToStringPtr(t *queries.Text) *string {
+	if t == nil {
+		return nil
+	}
+	v := string(*t)
+	return &v
 }
 
 const ReloadConfigQuery = `

--- a/pkg/pg/queries_test.go
+++ b/pkg/pg/queries_test.go
@@ -1,6 +1,7 @@
 package pg
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/dbtuneai/agent/pkg/agent"
@@ -16,7 +17,10 @@ func textPtr(s string) *queries.Text {
 
 func TestSettingsToConfigRows_IntegerVartype(t *testing.T) {
 	settings := []queries.PgSettingsRow{
-		{Name: "work_mem", Setting: "4096", Vartype: "integer", Context: "user", Unit: textPtr("kB")},
+		{
+			Name: "work_mem", Setting: "4096", Vartype: "integer", Context: "user",
+			Unit: textPtr("kB"), MinVal: textPtr("64"), MaxVal: textPtr("2147483647"),
+		},
 	}
 	got := settingsToConfigRows(settings)
 	require.Len(t, got, 1)
@@ -27,6 +31,12 @@ func TestSettingsToConfigRows_IntegerVartype(t *testing.T) {
 	assert.Equal(t, "kB", row.Unit)
 	assert.Equal(t, "integer", row.Vartype)
 	assert.Equal(t, "user", row.Context)
+
+	// Bounds relayed verbatim as strings, in the unit named by Unit.
+	require.NotNil(t, row.MinVal)
+	require.NotNil(t, row.MaxVal)
+	assert.Equal(t, "64", *row.MinVal)
+	assert.Equal(t, "2147483647", *row.MaxVal)
 }
 
 func TestSettingsToConfigRows_RealVartype(t *testing.T) {
@@ -51,6 +61,8 @@ func TestSettingsToConfigRows_StringVartype(t *testing.T) {
 	row := got[0].(agent.PGConfigRow)
 	assert.Equal(t, "UTC", row.Setting) // no InferNumericType for string vartype
 	assert.Equal(t, "string", row.Vartype)
+	assert.Nil(t, row.MinVal) // string vartypes have no bounds in pg_settings
+	assert.Nil(t, row.MaxVal)
 }
 
 func TestSettingsToConfigRows_EnumVartype(t *testing.T) {
@@ -70,6 +82,8 @@ func TestSettingsToConfigRows_BoolVartype(t *testing.T) {
 	row := got[0].(agent.PGConfigRow)
 	// "on" is not a numeric string, so it stays as string
 	assert.Equal(t, "on", row.Setting)
+	assert.Nil(t, row.MinVal) // bool vartypes have no bounds in pg_settings
+	assert.Nil(t, row.MaxVal)
 }
 
 func TestSettingsToConfigRows_NullUnit(t *testing.T) {
@@ -136,4 +150,42 @@ func TestPGMajorVersion(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestSettingsToConfigRows_RealBoundsNotCoerced(t *testing.T) {
+	settings := []queries.PgSettingsRow{
+		{
+			Name: "random_page_cost", Setting: "4", Vartype: "real", Context: "user",
+			MinVal: textPtr("0"), MaxVal: textPtr("1.79769e+308"),
+		},
+	}
+	got := settingsToConfigRows(settings)
+	row := got[0].(agent.PGConfigRow)
+
+	// Unlike Setting, bounds are never routed through InferNumericType.
+	require.NotNil(t, row.MinVal)
+	require.NotNil(t, row.MaxVal)
+	assert.Equal(t, "0", *row.MinVal)
+	assert.Equal(t, "1.79769e+308", *row.MaxVal)
+}
+
+func TestSettingsToConfigRows_BoundsOmittedFromJSONWhenNull(t *testing.T) {
+	settings := []queries.PgSettingsRow{
+		{Name: "jit", Setting: "on", Vartype: "bool", Context: "user"},
+		{
+			Name: "max_wal_size", Setting: "1024", Vartype: "integer", Context: "sighup",
+			Unit: textPtr("MB"), MinVal: textPtr("2"), MaxVal: textPtr("2147483647"),
+		},
+	}
+	got := settingsToConfigRows(settings)
+
+	boolJSON, err := json.Marshal(got[0])
+	require.NoError(t, err)
+	assert.NotContains(t, string(boolJSON), "min_val")
+	assert.NotContains(t, string(boolJSON), "max_val")
+
+	intJSON, err := json.Marshal(got[1])
+	require.NoError(t, err)
+	assert.Contains(t, string(intJSON), `"min_val":"2"`)
+	assert.Contains(t, string(intJSON), `"max_val":"2147483647"`)
 }


### PR DESCRIPTION
Part of DBT-2678. Closes DBT-2684.

Instead of determining the compiler and target, this PR simply sends the bounds of the parameters as part of the config payload. The backend will grab them and store them once the agent is spun up on a database, and we'll use that information to cap the search space.